### PR TITLE
[FIX] Correlogram: do not crash on a column with nans

### DIFF
--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -308,7 +308,9 @@ def interpolate_timeseries(data, method='linear', multivariate=False):
     for A in (X, Y):
         for i, col in enumerate(A.T):
             isnan = np.isnan(col)
-            if not isnan.any():
+            # there is no need to interpolate if there are no nans
+            # there needs to be at least two numbers
+            if not isnan.any() or sum(~isnan) < 2:
                 continue
 
             # Mean interpolation

--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -1,5 +1,3 @@
-from functools import lru_cache
-
 from Orange.data import Table, ContinuousVariable
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
@@ -7,11 +5,9 @@ from Orange.widgets.widget import Input
 
 from orangecontrib.timeseries import (
     Timeseries, autocorrelation, partial_autocorrelation)
-from orangecontrib.timeseries.util import cache_clears
 from orangecontrib.timeseries.widgets.highcharts import Highchart
 
 from AnyQt.QtWidgets import QListWidget
-from AnyQt.QtCore import QTimer
 
 
 class OWCorrelogram(widget.OWWidget):

--- a/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from Orange.data import Domain, ContinuousVariable
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries.widgets.owcorrelogram import OWCorrelogram
+
+
+class TestCorrelogramWidget(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWCorrelogram)  # type: OWCorrelogram
+
+    def test_nan_timeseries(self):
+        """
+        Widget used to crash because interpolation crashed when
+        there was a column with all nans or all nuns and only one number.
+        Now interpolation is skipped.
+        GH-27
+        """
+        time_series = Timeseries(
+            Domain(attributes=[ContinuousVariable("a"), ContinuousVariable("b")]),
+            list(zip(list(range(5)), list(range(5))))
+        )
+        time_series.X[:, 1] = np.nan
+        self.send_signal(self.widget.Inputs.time_series, time_series)
+        time_series.X[2, 1] = 42
+        self.send_signal(self.widget.Inputs.time_series, time_series)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
Widget crashes when doing interpolation if there is a column with only nans or a column with all nans but one.


##### Description of changes
Skips interpolation.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
