### PR TITLE
[FIX] As Timeseries: output None when error

### DIFF
--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -107,6 +107,7 @@ class OWTableToTimeseries(widget.OWWidget):
                                       source=data).metas.ravel()
             if np.isnan(values).any():
                 self.Error.nan_times(time_var.name)
+                self.Outputs.time_series.send(None)
                 return
             ordered = np.argsort(values)
             if (ordered != np.arange(len(ordered))).any():

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries.widgets.owtabletotimeseries import OWTableToTimeseries
+
+
+class TestAsTimeSeriesWidget(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWTableToTimeseries)  # type: OWTableToTimeseries
+
+    def test_timeseries_column_nans(self):
+        """
+        When cannot create Timeseries make sure output is None.
+        GH-30
+        """
+        w = self.widget
+        data = Table("iris")[:2]
+        self.assertFalse(w.Error.nan_times.is_shown())
+        self.send_signal(w.Inputs.data, data)
+        self.assertFalse(w.Error.nan_times.is_shown())
+        self.assertIsInstance(self.get_output(w.Outputs.time_series), Timeseries)
+        data.X[:, 0] = np.nan
+        self.send_signal(w.Inputs.data, data)
+        self.assertTrue(w.Error.nan_times.is_shown())
+        self.assertIsNone(self.get_output(w.Outputs.time_series))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
When we send data to widget **As Timeseries** and produce output and then send bad data to this widget error is shown but output stays the same.

##### Description of changes
Output set to `None` when error is shown.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
