### PR TITLE
[FIX] Timeseries: time_variable now created in Timeseries

### DIFF
--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -386,7 +386,7 @@ def seasonal_decompose(data, model='multiplicative', period=12, *, callback=None
     X = []
     recomposition = sub if model == 'additive' else truediv
     interp_data = data.interp()
-    for var in data.domain:
+    for var in data.domain.variables:
         decomposed = sm.tsa.seasonal_decompose(np.ravel(interp_data[:, var]),
                                                model=model,
                                                freq=period)
@@ -449,7 +449,7 @@ def granger_causality(data, max_lag=10, alpha=.05, *, callback=None):
     # http://statsmodels.sourceforge.net/devel/vector_ar.html#granger-causality
 
     data = data.interp()
-    domain = [var for var in data.domain if var.is_continuous]
+    domain = [var for var in data.domain.variables if var.is_continuous]
     res = []
 
     for row_attr in domain:

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -46,6 +46,12 @@ class Timeseries(Table):
 
     @time_variable.setter
     def time_variable(self, var):
+        if var is None:
+            self.attributes = self.attributes.copy()
+            if 'time_variable' in self.attributes:
+                self.attributes.pop('time_variable')
+            return
+
         assert var in self.domain
         self.attributes = self.attributes.copy()
         self.attributes['time_variable'] = var


### PR DESCRIPTION
##### Issue
Some widgets (**Seasonal Adjustment**, **Moving Transform**, and **Difference**) create `Timeseries` when they get `Table` and they do not set `time_variable`.


##### Description of changes
Scripting part which creates `time_variable` is now moved from widget **As Timeseries** to `Timeseries`.
Now this code can be used when creating `Timeseries` from `Table`.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
