### PR TITLE
[FIX] As Timeseries: can create sequential time variable and values

### DIFF
--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -78,7 +78,7 @@ class OWTableToTimeseries(widget.OWWidget):
     def commit(self):
         data = self.data
         self.Error.clear()
-        if data is None or self.selected_attr not in data.domain:
+        if data is None or (self.selected_attr not in data.domain and not self.radio_sequential):
             self.Outputs.time_series.send(None)
             return
 

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -29,6 +29,19 @@ class TestAsTimeSeriesWidget(WidgetTest):
         self.assertTrue(w.Error.nan_times.is_shown())
         self.assertIsNone(self.get_output(w.Outputs.time_series))
 
+    def test_non_cont_sequental(self):
+        """
+        Widget can create sequental time variable and values
+        if input data does not have any continuous variables.
+        GH-40
+        """
+        w = self.widget
+        table = Table("titanic")
+        self.send_signal(w.Inputs.data, table)
+        self.assertIsNone(self.get_output(w.Outputs.time_series))
+        w.controls.radio_sequential.buttons[1].click()
+        self.assertIsNotNone(self.get_output(w.Outputs.time_series))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
This widget cannot create sequential `time_variabe` if there are no `ContinuousVarible`
in input data.

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
