### PR TITLE
[FIX] Moving Transform: prevent crashing when no transforms

### DIFF
--- a/orangecontrib/timeseries/widgets/owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/owmovingtransform.py
@@ -5,7 +5,7 @@ from AnyQt.QtGui import QIcon
 from Orange.data import Domain, Table
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import VariableListModel, PyTableModel
-from Orange.widgets.widget import Input, Output
+from Orange.widgets.widget import Input, Output, Msg
 
 from orangecontrib.timeseries.widgets.utils import ListModel
 from orangecontrib.timeseries import Timeseries, moving_transform
@@ -44,6 +44,9 @@ class OWMovingTransform(widget.OWWidget):
                        'fixed-window-length-times shorter.'.format(_NON_OVERLAPPING_WINDOWS),
                        'non-overlapping')
     ]
+
+    class Warning(widget.OWWidget.Information):
+        no_transforms_added = Msg("At least one transform should be added.")
 
     def __init__(self):
         self.data = None
@@ -190,8 +193,14 @@ class OWMovingTransform(widget.OWWidget):
         self.commit()
 
     def commit(self):
+        self.Warning.no_transforms_added.clear()
         data = self.data
         if not data:
+            self.Outputs.time_series.send(None)
+            return
+
+        if not len(self.table_model):
+            self.Warning.no_transforms_added()
             self.Outputs.time_series.send(None)
             return
 

--- a/orangecontrib/timeseries/widgets/tests/test_owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owmovingtransform.py
@@ -1,0 +1,33 @@
+import unittest
+
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries.widgets.owmovingtransform import OWMovingTransform
+
+
+class TestOWMovingTransform(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWMovingTransform)  # type: OWMovingTransform
+
+    def test_no_transforms_added(self):
+        """
+        Prevent crashing when no transforms are added.
+        GH-42
+        """
+        w = self.widget
+        table = Table("airpassengers")
+        self.assertFalse(w.non_overlapping)
+        w.controls.non_overlapping.click()
+        self.assertTrue(w.non_overlapping)
+        self.send_signal(w.Inputs.time_series, table)
+        self.assertFalse(w.Warning.no_transforms_added.is_shown())
+        w.controls.autocommit.click()
+        self.assertTrue(w.Warning.no_transforms_added.is_shown())
+        w.add_button.click()
+        w.controls.autocommit.click()
+        self.assertFalse(w.Warning.no_transforms_added.is_shown())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
Connect **File** and **Moving Transform**. Click _Non-overlapping windows_. It has to be checked. Then click _Apply_. The widget crashes.


##### Description of changes
Do not commit if there are no Transforms selected.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
