### PR TITLE
[FIX] Timeseries: use a valid dataset and some cleaning

### DIFF
--- a/orangecontrib/timeseries/widgets/owaggregate.py
+++ b/orangecontrib/timeseries/widgets/owaggregate.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
 
     a = QApplication([])
     ow = OWAggregate()
-    ow.set_data(Timeseries('autoroute'))
+    ow.set_data(Timeseries('airpassengers'))
 
     ow.show()
     a.exec()

--- a/orangecontrib/timeseries/widgets/owarimamodel.py
+++ b/orangecontrib/timeseries/widgets/owarimamodel.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWARIMAModel()
 
-    data = Timeseries('yahoo')
+    data = Timeseries('airpassengers')
     domain = Domain(data.domain.attributes[:-1], data.domain.attributes[-1])
     data = Timeseries.from_numpy(domain, data.X[:, :-1], data.X[:, -1])
     ow.set_data(data)

--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -122,8 +122,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWCorrelogram()
 
-    # data = Timeseries('yahoo_MSFT')
-    data = Timeseries('UCI-SML2010-1')
+    data = Timeseries('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owdifference.py
+++ b/orangecontrib/timeseries/widgets/owdifference.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWDifference()
 
-    data = Timeseries('yahoo_MSFT')
+    data = Timeseries('airpassengers')
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:

--- a/orangecontrib/timeseries/widgets/owgrangercausality.py
+++ b/orangecontrib/timeseries/widgets/owgrangercausality.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWGrangerCausality()
 
-    data = Timeseries('yahoo_MSFT')
+    data = Timeseries('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -8,10 +8,10 @@ from Orange.data import TimeVariable, Table
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.widget import Input
 
-from AnyQt.QtWidgets import QTreeWidget, QSizePolicy, \
+from AnyQt.QtWidgets import QTreeWidget, \
     QWidget, QPushButton, QListView, QVBoxLayout
 from AnyQt.QtGui import QIcon
-from AnyQt.QtCore import Qt, QSize, pyqtSignal, QTimer
+from AnyQt.QtCore import QSize, pyqtSignal, QTimer
 
 from Orange.widgets.utils.itemmodels import VariableListModel
 from orangecontrib.timeseries import Timeseries
@@ -419,12 +419,11 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWLineChart()
 
-    msft = Timeseries('yahoo_MSFT')
-    ow.set_data(msft),
-    # ow.set_data(Timeseries('UCI-SML2010-1'))
+    airpassengers = Timeseries('airpassengers')
+    ow.set_data(airpassengers),
 
-    msft = msft.interp()
-    model = ARIMA((3, 1, 1)).fit(msft)
+    msft = airpassengers.interp()
+    model = ARIMA((3, 1, 1)).fit(airpassengers)
     ow.set_forecast(model.predict(10, as_table=True), 0)
     model = VAR(4).fit(msft)
     ow.set_forecast(model.predict(10, as_table=True), 1)

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWModelEvaluation()
 
-    data = Timeseries('yahoo_MSFT')
+    data = Timeseries('airpassengers')
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:

--- a/orangecontrib/timeseries/widgets/owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/owmovingtransform.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWMovingTransform()
 
-    data = Timeseries('yahoo_MSFT')
+    data = Timeseries('airpassengers')
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:
         # Make Adjusted Close a class variable

--- a/orangecontrib/timeseries/widgets/owperiodogram.py
+++ b/orangecontrib/timeseries/widgets/owperiodogram.py
@@ -116,9 +116,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWPeriodogram()
 
-    data = Timeseries('yahoo_MSFT')
-    data = Timeseries('autoroute')
-    # data = Timeseries('UCI-SML2010-1')
+    data = Timeseries('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/owseasonaladjustment.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from AnyQt.QtWidgets import QListView
 from AnyQt.QtCore import Qt
 
@@ -136,7 +134,6 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWSeasonalAdjustment()
 
-    # data = Timeseries('yahoo_MSFT')
     data = Timeseries('airpassengers')
     if not data.domain.class_var and 'Adj Close' in data.domain:
         # Make Adjusted Close a class variable

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -6,9 +6,9 @@ from collections import defaultdict
 from os import path
 
 import numpy as np
-from Orange.util import color_to_hex
 
 from Orange.data import Table, Domain, TimeVariable, DiscreteVariable
+from Orange.util import color_to_hex
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.colorpalette import GradientPaletteGenerator
 from Orange.widgets.utils.itemmodels import VariableListModel
@@ -22,6 +22,7 @@ from orangecontrib.timeseries.widgets.highcharts import Highchart
 from AnyQt.QtWidgets import QListView
 from AnyQt.QtCore import QItemSelectionModel
 from AnyQt.QtGui import QColor
+
 
 class Spiralogram(Highchart):
     """

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -120,12 +120,12 @@ class OWTableToTimeseries(widget.OWWidget):
 
 
 if __name__ == "__main__":
-    from AnyQt.QtWidgets import QApplication, QLabel
+    from AnyQt.QtWidgets import QApplication
 
     a = QApplication([])
     ow = OWTableToTimeseries()
 
-    data = Timeseries('yahoo1')
+    data = Timeseries('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 
-import numpy as np
 import operator
 from collections import OrderedDict
 
@@ -293,7 +292,7 @@ if __name__ == '__main__':
     from AnyQt.QtWidgets import QApplication
     app = QApplication([])
     w = OWTimeSlice()
-    data = Table('/tmp/airpassengers.csv')
+    data = Table('airpassengers')
     w.set_data(data)
     w.show()
     app.exec()

--- a/orangecontrib/timeseries/widgets/owvarmodel.py
+++ b/orangecontrib/timeseries/widgets/owvarmodel.py
@@ -55,12 +55,11 @@ class OWVARModel(OWBaseModel):
 
 if __name__ == "__main__":
     from AnyQt.QtWidgets import QApplication
-    from Orange.data import Domain
 
     a = QApplication([])
     ow = OWVARModel()
 
-    data = Timeseries('yahoo_MSFT')
+    data = Timeseries('airpassengers')
     ow.set_data(data)
 
     ow.show()


### PR DESCRIPTION
##### Issue
Widgets cannot be run independently due to missing datasets.

Some unused imports.

See also #41 .

##### Description of changes
Unused imports removed.
Unavailable datasets replaced by `airpassengers`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
