### PR TITLE
[FIX] Correlogram: at least two instances are required

### DIFF
--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -26,6 +26,9 @@ class OWCorrelogram(widget.OWWidget):
 
     graph_name = 'plot'
 
+    class Error(widget.OWWidget.Error):
+        no_instances = widget.Msg("At least 2 data instances are required")
+
     def __init__(self):
         self.all_attrs = []
         opts = gui.widgetBox(self.controlArea, 'Options')
@@ -66,9 +69,14 @@ class OWCorrelogram(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
+        self.Error.no_instances.clear()
         self.data = data = None if data is None else Timeseries.from_data_table(data)
         self.all_attrs = []
         if data is None:
+            self.plot.clear()
+            return
+        if len(data) < 2:
+            self.Error.no_instances()
             self.plot.clear()
             return
         self.all_attrs = [(var.name, gui.attributeIconDict[var])

--- a/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
@@ -29,6 +29,21 @@ class TestCorrelogramWidget(WidgetTest):
         time_series.X[2, 1] = 42
         self.send_signal(self.widget.Inputs.time_series, time_series)
 
+    def test_no_instances(self):
+        """
+        At least two instances are required.
+        GH-45
+        """
+        def assert_error_shown(data, is_shown):
+            self.send_signal(self.widget.Inputs.time_series, data)
+            self.assertEqual(self.widget.Error.no_instances.is_shown(), is_shown)
+
+        ts = Timeseries("airpassengers")
+
+        self.assertFalse(self.widget.Error.no_instances.is_shown())
+        for data, is_shown in ((ts[:1], True), (ts, False), (ts[:0], True), (None, False)):
+            assert_error_shown(data, is_shown)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
**Correlogram** crashes when gets data with less than two instances.

When it gets data with one instance it crashes due to a (possible) bug in `statsmodels`.

```python
x = np.squeeze(np.asarray(x))
```
See: https://github.com/statsmodels/statsmodels/blob/a222cec7c80a608a3213c586e8a71d666f91d60b/statsmodels/tsa/stattools.py#L326

That line returns a `<class 'numpy.ndarray'>` where `x.ndim` is `0`.

And later fails:
```python
n = len(x)
```
https://github.com/statsmodels/statsmodels/blob/a222cec7c80a608a3213c586e8a71d666f91d60b/statsmodels/tsa/stattools.py#L357

##### Description of changes
Show an error message and do the same when data is `None`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
