### PR TITLE
[FIX] Line Chart: do not crash on no data

### DIFF
--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -161,7 +161,6 @@ class Highstock(Highchart):
         ci_percents = []
 
         data = self.parent.data
-        delta = data.time_delta if isinstance(data.time_variable, TimeVariable) else None
 
         for attr in series:
             newseries.append(data.get_column_view(attr)[0])
@@ -386,6 +385,7 @@ class OWLineChart(widget.OWWidget):
 
         self.data = data = None if data is None else Timeseries.from_data_table(data)
         if data is None:
+            self.varmodel.clear()
             self.chart.clear()
             return
         if getattr(data.time_variable, 'utc_offset', False):

--- a/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
@@ -1,0 +1,28 @@
+import unittest
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries.widgets.owlinechart import OWLineChart
+
+
+class TestOWLineChart(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWLineChart)  # type: OWLineChart
+
+    def test_no_time_series(self):
+        """
+        Clean variables list view when no data.
+        GH-46
+        """
+        w = self.widget
+        time_series = Timeseries("airpassengers")
+        self.send_signal(w.Inputs.time_series, time_series)
+        self.send_signal(w.Inputs.time_series, None)
+        self.send_signal(w.Inputs.forecast, time_series, 1)
+        w.configs[0].view.selectAll()
+        w.configs[0].selection_changed()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
Dead code has been causing errors.
List of variables is not emptied when there is no data.

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
