### PR TITLE
[FIX] Granger Causality: new signals compatibility

### DIFF
--- a/orangecontrib/timeseries/widgets/owgrangercausality.py
+++ b/orangecontrib/timeseries/widgets/owgrangercausality.py
@@ -18,7 +18,7 @@ class OWGrangerCausality(widget.OWWidget):
     priority = 190
 
     class Inputs:
-        time_series = Input("Time series", Table)
+        time_series = Input("Time series", Table, replaces=["Timeseries"])
 
     max_lag = settings.Setting(20)
     confidence = settings.Setting(95)


### PR DESCRIPTION
##### Issue
Error occurred in #26 .
Old signal name `Timeseries` has been renamed to `Time series`.

##### Description of changes
Add compatibility.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
