### PR TITLE
[FIX] Spiralogram: do not crash on a new data

### DIFF
--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -370,7 +370,8 @@ class OWSpiralogram(widget.OWWidget):
                          for i in range(1, self.combo_ax1.count())), self.ax2)
         self.agg_attr = [data.domain.variables[0]] if len(data.domain.variables) else []
         self.agg_func = 0
-        self.openContext(data.domain)
+        if getattr(data, 'time_variable', None) is not None:
+            self.openContext(data.domain)
 
         if self.agg_attr:
             self.attrlist.blockSignals(True)

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -300,12 +300,18 @@ class OWSpiralogram(widget.OWWidget):
         self.data = None
         self.indices = []
         box = gui.vBox(self.controlArea, 'Axes')
+        self.combo_ax2_model = VariableListModel(parent=self)
+        self.combo_ax1_model = VariableListModel(parent=self)
+        for model in (self.combo_ax1_model, self.combo_ax2_model):
+            model[:] = [_enum_str(i) for i in Spiralogram.AxesCategories]
         self.combo_ax2 = gui.comboBox(
             box, self, 'ax2', label='Y axis:', callback=self.replot,
-            sendSelectedValue=True, orientation='horizontal')
+            sendSelectedValue=True, orientation='horizontal',
+            model=self.combo_ax2_model)
         self.combo_ax1 = gui.comboBox(
             box, self, 'ax1', label='Radial:', callback=self.replot,
-            sendSelectedValue=True, orientation='horizontal')
+            sendSelectedValue=True, orientation='horizontal',
+            model=self.combo_ax1_model)
         gui.checkBox(box, self, 'invert_date_order', 'Invert Y axis order',
                      callback=self.replot)
 
@@ -339,21 +345,20 @@ class OWSpiralogram(widget.OWWidget):
         self.data = data = None if data is None else Timeseries.from_data_table(data)
 
         def init_combos():
-            for combo in (self.combo_ax1, self.combo_ax2):
-                combo.clear()
+            for model in (self.combo_ax1_model, self.combo_ax2_model):
+                model.clear()
             newmodel = []
             if data is not None and data.time_variable is not None:
-                for i in Spiralogram.AxesCategories:
-                    for combo in (self.combo_ax1, self.combo_ax2):
-                        combo.addItem(_enum_str(i))
+                for model in (self.combo_ax1_model, self.combo_ax2_model):
+                    model[:] = [_enum_str(i) for i in Spiralogram.AxesCategories]
             for var in data.domain.variables if data is not None else []:
                 if (var.is_primitive() and
                         (var is not data.time_variable or
                          isinstance(var, TimeVariable) and data.time_delta is None)):
                     newmodel.append(var)
                 if var.is_discrete:
-                    for combo in (self.combo_ax1, self.combo_ax2):
-                        combo.addItem(gui.attributeIconDict[var], var.name)
+                    for model in (self.combo_ax1_model, self.combo_ax2_model):
+                        model.append(var)
             self.attrlist_model.wrap(newmodel)
 
         init_combos()

--- a/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
@@ -1,0 +1,27 @@
+import unittest
+
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries.widgets.owspiralogram import OWSpiralogram
+
+
+class TestOWSpiralogram(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWSpiralogram)  # type: OWSpiralogram
+
+    def test_new_data(self):
+        """
+        Widget crashes when it gets new data with different domain.
+        GH-50
+        """
+        w = self.widget
+        time_series = Timeseries("airpassengers")
+        table = Table("iris")
+        self.send_signal(w.Inputs.time_series, time_series)
+        self.send_signal(w.Inputs.time_series, table)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
Widget might crash when new data is sent because of `openContext`. New data might not have `time_variable` and `contextHandler` wants to set `ax1` and `ax2` variables as `monthly`, etc.

##### Description of changes
~Use `PerfectDomainContextHandler` instead of `ContextHandler`.~
Check if `data` has a `.time_variable`.

Also: Use `VariableListModel` instead of filling combos.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
