### PR TITLE
OWTabletoTimeseries: Accept meta attributes

### DIFF
--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -64,11 +64,13 @@ class OWTableToTimeseries(widget.OWWidget):
             self.commit()
             return
         if data.domain.has_continuous_attributes():
-            vars = [var for var in data.domain.variables if isinstance(var, TimeVariable)] + \
+            vars = [var for var in data.domain.variables if var.is_time] + \
+                   [var for var in data.domain.metas if var.is_time] + \
                    [var for var in data.domain.variables
-                    if var.is_continuous and not isinstance(var, TimeVariable)]
+                    if var.is_continuous and not var.is_time] + \
+                   [var for var in data.domain.metas if var.is_continuous and
+                    not var.is_time]
             self.attrs_model.wrap(vars)
-            # self.selected_attr = vars.index(getattr(data, 'time_variable', vars[0]))
             self.selected_attr = data.time_variable.name if getattr(data, 'time_variable', False) else vars[0].name
         self.on_changed()
 

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from Orange.data import Domain
 
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
@@ -12,6 +13,19 @@ from orangecontrib.timeseries.widgets.owtabletotimeseries import OWTableToTimese
 class TestAsTimeSeriesWidget(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWTableToTimeseries)  # type: OWTableToTimeseries
+
+    def test_time_as_metas(self):
+        """
+        As Timeseries should accept attributes from X and metas.
+        """
+        w = self.widget
+        data = Table("cyber-security-breaches")[:20]
+        self.send_signal(w.Inputs.data, data)
+        self.assertEqual(len(w.attrs_model), 4)
+        new_domain = Domain(data.domain[:6], metas=[data.domain[6]])
+        new_data = Table(new_domain, data)
+        self.send_signal(w.Inputs.data, new_data)
+        self.assertEqual(len(w.attrs_model), 4)
 
     def test_timeseries_column_nans(self):
         """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #51. 

##### Description of changes
Accept meta attributes in As Timeseries widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
