### PR TITLE
Fix teststs and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,29 @@
 language: python
-sudo: false   # use container-based infrastructure
-dist: trusty
-python: "3.5"
+dist: xenial # trusty doesn't support Py3.7
 
 cache:
     apt: true
     pip: true
     ccache: true
 
+matrix:
+    include:
+        - &python36
+          python: '3.6'
+        - &python37
+          python: '3.7'
+
 before_install:
     - pip install -U setuptools pip wheel
     - pip install codecov
 
 install:
-    - pip install PyQt5==5.9.2 AnyQt
+    - pip install pyqt5==5.11.*
     - travis_wait pip install -e .
 
 script:
-    - catchsegv xvfb-run -a -s "-screen 0 1280x1024x24" coverage run setup.py test
+    - XVFBARGS="-screen 0 1280x1024x24"
+    - catchsegv xvfb-run -a -s "$XVFBARGS" coverage run setup.py test
 
 after_success:
     - codecov

--- a/orangecontrib/timeseries/tests/__init__.py
+++ b/orangecontrib/timeseries/tests/__init__.py
@@ -3,9 +3,11 @@ import unittest
 
 
 def suite(loader=unittest.TestLoader(), pattern='test*.py'):
-    this_dir = os.path.dirname(__file__)
-    package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
-    return package_tests
+    """Loads all project's tests."""
+    dir_ = os.path.dirname(os.path.dirname(__file__))
+    top_level = os.path.realpath(os.path.join(dir_, "..", ".."))
+    all_tests = loader.discover(dir_, pattern, top_level_dir=top_level)
+    return unittest.TestSuite(all_tests)
 
 
 if __name__ == '__main__':

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -19,7 +19,8 @@ class TestAsTimeSeriesWidget(WidgetTest):
         As Timeseries should accept attributes from X and metas.
         """
         w = self.widget
-        data = Table("cyber-security-breaches")[:20]
+        data = Table(
+            "http://file.biolab.si/datasets/cyber-security-breaches.tab")[:20]
         self.send_signal(w.Inputs.data, data)
         self.assertEqual(len(w.attrs_model), 4)
         new_domain = Domain(data.domain[:6], metas=[data.domain[6]])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import unittest
 from setuptools import setup, find_packages
 
 VERSION = '0.3.3'
@@ -29,14 +28,6 @@ ENTRY_POINTS = {
         'html-index = orangecontrib.timeseries.widgets:WIDGET_HELP_PATH',
     )
 }
-
-
-# http://stackoverflow.com/a/37033551/892987
-def discover_tests():
-    return unittest.defaultTestLoader.discover(
-        'orangecontrib.timeseries',
-        pattern='test_*.py',
-        top_level_dir='.')
 
 
 if __name__ == '__main__':
@@ -77,7 +68,7 @@ if __name__ == '__main__':
             'scipy>=0.17',
         ],
         entry_points=ENTRY_POINTS,
-        test_suite='setup.discover_tests',
+        test_suite='orangecontrib.timeseries.tests.suite',
         namespace_packages=['orangecontrib'],
         zip_safe=False,
         classifiers=[


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Continuing from https://github.com/biolab/orange3-timeseries/pull/64

##### Description of changes

@ajdapretnar since I couldn't push to your PR I opened a new one including your commit.

This PR changes:

- Run Travis on Python 3.6 and Python 3.7.
- A test suite is changed to fix the import error.

##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation
