### PR TITLE
Change the minimal version for statsmodels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         },
         install_requires=[
             'Orange3',
-            'statsmodels>=0.6.1',
+            'statsmodels>=0.10.0',
             'pandas',  # statsmodels requires this but doesn't have it in dependencies?
             'pandas_datareader',
             'numpy',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements https://github.com/biolab/orange3-timeseries/issues/62

##### Description of changes

Statsmodels released new version 0.10.0 which is compatible with Scipy 1.3 so we limit the version to of statsmodels to be at least 0.10.0

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
