### PR TITLE
Spiralogram: cast DiscreteVariable into string

### DIFF
--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -6,7 +6,7 @@ from os import path
 
 import numpy as np
 
-from Orange.data import Table, Domain, TimeVariable, DiscreteVariable
+from Orange.data import Table, TimeVariable, DiscreteVariable
 from Orange.util import color_to_hex
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.colorpalette import GradientPaletteGenerator
@@ -257,6 +257,8 @@ class Spiralogram(Highchart):
 
 
 def _enum_str(enum_value, inverse=False):
+    if isinstance(enum_value, DiscreteVariable):
+        enum_value = str(enum_value)
     if inverse:
         return enum_value.replace(' ', '_').upper()
     return enum_value.name.replace('_', ' ').lower()

--- a/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
@@ -5,6 +5,7 @@ from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.timeseries import Timeseries
 from orangecontrib.timeseries.widgets.owspiralogram import OWSpiralogram
+from Orange.widgets.tests.utils import simulate
 
 
 class TestOWSpiralogram(WidgetTest):
@@ -54,6 +55,16 @@ class TestOWSpiralogram(WidgetTest):
         self.select_item(w, 0)
         output = self.get_output(w.Outputs.time_series)
         self.assertEqual(output[0][0], "1949-01-01")
+
+    def test_cb_axes(self):
+        """ Test that all possible axes work, including discrete variables. """
+        w = self.widget
+        data = Timeseries.from_url('http://datasets.orange.biolab.si/core/philadelphia-crime.csv.xz')
+        self.send_signal(w.Inputs.time_series, data)
+        # test all possibilities for Y axis
+        simulate.combobox_run_through_all(w.combo_ax2)
+        # test all possibilites for radial
+        simulate.combobox_run_through_all(w.combo_ax1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Spiralogram apparently supports discrete variables on radius, but they didn't work properly.

##### Description of changes
Cast DiscreteVariables into strings.
Tests.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
