### PR TITLE
OWTimeSlice: Spring cleaning

### DIFF
--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -175,10 +175,11 @@ class Timeseries(Table):
         values = table.get_column_view(time_var)[0]
         # Filter out NaNs
         nans = np.isnan(values)
+        if nans.all():
+            return None
         if nans.any():
             values = values[~nans]
             table = table[~nans]
-            return
         # Sort!
         ordered = np.argsort(values)
         if (ordered != np.arange(len(ordered))).any():

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -21,7 +21,17 @@ class TimeDelta:
         self.time_values = time_values
         self.backwards_compatible_delta = self._get_backwards_compatible_delta()
 
-        self._deltas = deltas = np.sort(np.unique(np.diff(self.time_values)))
+        deltas = list(np.sort(np.unique(np.diff(self.time_values))))
+        # TODO detect multiple days/months/years
+        for i, d in enumerate(deltas[:]):
+            if d in self._SPAN_DAY:
+                deltas[i] = (1, 'day')
+            elif d in self._SPAN_MONTH:
+                deltas[i] = (1, 'month')
+            elif d in self._SPAN_YEAR:
+                deltas[i] = (1, 'year')
+        self._deltas = deltas
+
         self.is_equispaced = len(deltas) == 1
 
     def _get_backwards_compatible_delta(self):

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -1,4 +1,5 @@
 import itertools
+from more_itertools import unique_everseen
 import numpy as np
 
 from Orange.data import Table, Domain, TimeVariable, ContinuousVariable
@@ -21,6 +22,12 @@ class TimeDelta:
         self.time_values = time_values
         self.backwards_compatible_delta = self._get_backwards_compatible_delta()
 
+        if len(time_values) <= 1:
+            self.deltas = []
+            self.is_equispaced = True
+            self.min = None
+            return
+
         deltas = list(np.sort(np.unique(np.diff(self.time_values))))
         # TODO detect multiple days/months/years
         for i, d in enumerate(deltas[:]):
@@ -30,7 +37,10 @@ class TimeDelta:
                 deltas[i] = (1, 'month')
             elif d in self._SPAN_YEAR:
                 deltas[i] = (1, 'year')
-        self._deltas = deltas
+        # in case several months or years of different length were matched,
+        # run it through another unique check
+        deltas = list(unique_everseen(deltas))
+        self.deltas = deltas
 
         self.is_equispaced = len(deltas) == 1
         self.min = deltas[0]

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -33,6 +33,7 @@ class TimeDelta:
         self._deltas = deltas
 
         self.is_equispaced = len(deltas) == 1
+        self.min = deltas[0]
 
     def _get_backwards_compatible_delta(self):
         """

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -91,6 +91,12 @@ class Timeseries(Table):
         try:
             time_variable = next(var for var in search
                                  if var.is_time)
+            values = table.get_column_view(time_variable)[0]
+            if np.issubdtype(values.dtype, np.number):
+                # Filter out NaNs
+                nans = np.isnan(values)
+                if nans.any():
+                    table = table[~nans]
             ts = super(Timeseries, cls).from_table(table.domain, table)
             ts.time_variable = time_variable
             return ts

--- a/orangecontrib/timeseries/util.py
+++ b/orangecontrib/timeseries/util.py
@@ -1,3 +1,10 @@
+import calendar
+import logging
+from datetime import datetime, timedelta
+from numbers import Number
+
+log = logging.getLogger(__name__)
+
 
 def cache_clears(*caches):
     def decorator(func):
@@ -8,3 +15,36 @@ def cache_clears(*caches):
             return func(*args, **kwargs)
         return f
     return decorator
+
+
+def add_time(start_dt: datetime.date, delta, quantity):
+    if isinstance(delta, Number):
+        return start_dt + timedelta(delta * quantity)
+    quantity = delta[0] * quantity
+    if delta:
+        if delta[1] == 'day':
+            return start_dt + timedelta(days=quantity)
+        elif delta[1] == 'month':
+            years = int(quantity / 12)
+            months = quantity - years * 12
+            months_result = start_dt.month + months
+            if months_result < 1:
+                years -= 1
+                months_result += 12
+            elif 12 < months_result:
+                years += 1
+                months_result -= 12
+            years_result = start_dt.year + years
+            last_calendar_day = calendar.monthrange(years_result, months_result)[1]
+            return start_dt.replace(
+                day=min(start_dt.day, last_calendar_day),
+                month=months_result,
+                year=years_result
+            )
+        else:  # elif delta[1] == 'year':
+            return start_dt.replace(
+                year=start_dt.year + quantity,
+            )
+    log.warning('"None" timedelta supplied when adding time, '
+                'not adding any time')
+    return start_dt

--- a/orangecontrib/timeseries/widgets/_rangeslider.py
+++ b/orangecontrib/timeseries/widgets/_rangeslider.py
@@ -135,6 +135,7 @@ class RangeSlider(QSlider):
         else:
             self.setValues(self._min_position, self._max_position)
         self.update()
+        self.slidersMoved.emit(self._min_position, self._max_position)
 
     def mousePressEvent(self, event):
         if not event.button():
@@ -184,6 +185,8 @@ class RangeSlider(QSlider):
                 self._min_position = low_v
                 self._max_position = hi_v
                 self.update()
+                self.setValues(self._min_position,
+                               self._max_position)
                 self.slidersMoved.emit(self._min_position,
                                        self._max_position)
 

--- a/orangecontrib/timeseries/widgets/_rangeslider.py
+++ b/orangecontrib/timeseries/widgets/_rangeslider.py
@@ -194,11 +194,20 @@ class RangeSlider(QSlider):
 
         if self.__active_slider < 0:
             # Moving the time window
+            width = self.__max_position - self.__min_position
             offset = pos - self.__click_offset
-            self.__max_position = min(self.__max_position + offset,
-                                      self.maximum())
-            self.__min_position = max(self.__min_position + offset,
-                                      self.minimum())
+            if offset >= 0:
+                self.__max_position = min(self.maximum(),
+                                          self.__max_position + offset)
+                self.__min_position = max(self.minimum(),
+                                          min(self.__min_position + offset,
+                                              self.__max_position - width))
+            else:
+                self.__min_position = max(self.minimum(),
+                                          self.__min_position + offset)
+                self.__max_position = min(self.maximum(),
+                                          max(self.__max_position + offset,
+                                              self.__min_position + width))
             self.__click_offset = pos
         else:
             # Moving a handle

--- a/orangecontrib/timeseries/widgets/_rangeslider.py
+++ b/orangecontrib/timeseries/widgets/_rangeslider.py
@@ -155,11 +155,27 @@ class RangeSlider(QSlider):
             self.__click_offset = pos
         else:
             if self.__active_slider == 0:
-                self.__min_position = max(self.minimum(), pos)
-                self.__max_position = min(self.maximum(), max(self.__max_position, self.__min_position + 1))
+                if self.__max_position <= pos < self.maximum():
+                    self.__active_slider = 1
+                    self.__min_position = self.__max_position
+                    self.__max_position = min(self.maximum(),
+                                              max(pos,
+                                                  self.__min_position + 1))
+                else:
+                    self.__min_position = max(self.minimum(),
+                                              min(pos,
+                                                  self.__max_position - 1))
             else:
-                self.__max_position = min(self.maximum(), pos)
-                self.__min_position = max(self.minimum(), min(self.__min_position, self.__max_position - 1))
+                if self.minimum() < pos <= self.__min_position:
+                    self.__active_slider = 0
+                    self.__max_position = self.__min_position
+                    self.__min_position = max(self.minimum(),
+                                              min(pos,
+                                                  self.__max_position - 1))
+                else:
+                    self.__max_position = min(self.maximum(),
+                                              max(pos,
+                                                  self.__min_position + 1))
 
         self.update()
         self.slidersMoved.emit(self.__min_position, self.__max_position)

--- a/orangecontrib/timeseries/widgets/_rangeslider.py
+++ b/orangecontrib/timeseries/widgets/_rangeslider.py
@@ -465,18 +465,19 @@ class ViolinSlider(RangeSlider):
         painter.setOpacity(1)
 
         if self._show_text:
-            painter.setFont(QFont('sans-serif', 7, QFont.Bold))
+            painter.setFont(QFont('Monospace', 7, QFont.Bold))
             strMin, strMax = self.formatValues(minpos, maxpos)
             widthMin = painter.fontMetrics().width(strMin)
             widthMax = painter.fontMetrics().width(strMax)
             height = painter.fontMetrics().height()
-            is_enough_space = x2 - x1 > 2 + (max(widthMax, widthMin)
+            is_enough_space = x2 - x1 > 3 + (max(widthMax, widthMin)
                                              if is_horizontal else
                                              (2 * height + self._HANDLE_WIDTH))
             if is_enough_space:
                 if is_horizontal:
-                    painter.drawText(x1 + 3, rect.y() + height - 2, strMin)
-                    painter.drawText(x2 - widthMax - 1, rect.y() + rect.height() - 2, strMax)
+                    painter.drawText(x1 + 3, rect.y() + height, strMin)
+                    painter.drawText(x2 - widthMax - 2,
+                                     rect.y() + rect.height() - 3, strMax)
                 else:
                     painter.drawText(rect.x() + 1, x1 + height, strMin)
                     painter.drawText(rect.x() + rect.width() - widthMax - 1, x2 - 2, strMax)

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -139,7 +139,8 @@ class OWTimeSlice(widget.OWWidget):
                                  timeout=self.play_single_step)
         slider = self.slider = Slider(Qt.Horizontal, self,
                                       minimum=0, maximum=self.MAX_SLIDER_VALUE,
-                                      tracking=False,
+                                      tracking=True,
+                                      playbackInterval=self.playback_interval,
                                       valuesChanged=self.sliderValuesChanged,
                                       minimumValue=self.slider_values[0],
                                       maximumValue=self.slider_values[1])
@@ -197,7 +198,8 @@ class OWTimeSlice(widget.OWWidget):
         gui.spin(vbox, self, 'playback_interval',
                  label='Playback delay (msec):',
                  minv=100, maxv=30000, step=200,
-                 callback=lambda: self.play_timer.setInterval(self.playback_interval))
+                 callback=lambda: (self.play_timer.setInterval(self.playback_interval),
+                                   self.slider.tracking_timer.setInterval(self.playback_interval)))
 
         hbox = gui.hBox(vbox)
         self.step_backward = gui.button(hbox, self, '⏮',

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -249,6 +249,10 @@ class OWTimeSlice(widget.OWWidget):
                        self.step_backward):
             widget.setDisabled(playing)
 
+        for widget in (self.date_from,
+                       self.date_to):
+            widget.setReadOnly(playing)
+
         if playing:
             self.play_timer.start()
             self.play_button.setText('▮▮')

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -169,6 +169,14 @@ class OWTimeSlice(widget.OWWidget):
         date_from.dateTimeChanged.connect(lambda: datetime_edited(date_from))
         date_to.dateTimeChanged.connect(lambda: datetime_edited(date_to))
 
+        # hotfix, does not repaint on click of arrow
+        date_from.calendarWidget().currentPageChanged.connect(
+            lambda: date_from.calendarWidget().repaint()
+        )
+        date_to.calendarWidget().currentPageChanged.connect(
+            lambda: date_to.calendarWidget().repaint()
+        )
+
         hbox.layout().addStretch(100)
         hbox.layout().addWidget(date_from)
         hbox.layout().addWidget(QLabel(' – '))
@@ -260,6 +268,9 @@ class OWTimeSlice(widget.OWWidget):
             self.play_timer.stop()
             self.play_button.setText('▶')
 
+        # hotfix
+        self.repaint()
+
     def play_single_step(self, backward=False):
         op = operator.sub if backward else operator.add
         minValue, maxValue = self.slider.values()
@@ -293,6 +304,9 @@ class OWTimeSlice(widget.OWWidget):
             self.slider.setValues(minValue, maxValue)
         self.sliderValuesChanged(self.slider.minimumValue(), self.slider.maximumValue())
         self._delta = orig_delta  # Override valuesChanged handler
+
+        # hotfix
+        self.slider.repaint()
 
     def _set_disabled(self, is_disabled):
         for func in [self.date_from, self.date_to, self.step_backward, self.play_button,

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -116,6 +116,7 @@ class OWTimeSlice(widget.OWWidget):
 
     class Error(widget.OWWidget.Error):
         no_time_variable = widget.Msg('Data contains no time variable')
+        no_time_delta = widget.Msg('Data contains only 1 row')
 
     MAX_SLIDER_VALUE = 500
     DATE_FORMATS = ('yyyy', '-MM', '-dd', '  HH:mm:ss.zzz')
@@ -384,6 +385,10 @@ class OWTimeSlice(widget.OWWidget):
             self.Error.no_time_variable()
             disabled()
             return
+        if not data.time_delta.deltas:
+            self.Error.no_time_delta()
+            disabled()
+            return
         self.Error.clear()
         var = data.time_variable
 
@@ -415,7 +420,7 @@ class OWTimeSlice(widget.OWWidget):
                     break
             else:
                 min_overlap = '1 day'
-        elif delta:
+        else:  # isinstance(delta, tuple)
             if delta[1] == 'day':
                 maximum = range.days / delta[0]
 
@@ -485,15 +490,6 @@ class OWTimeSlice(widget.OWWidget):
                         break
                 else:
                     raise Exception('Timedelta larger than 100 years')
-        else:
-            maximum = _TimeSliderMixin.DEFAULT_SCALE_LENGTH
-
-            max_dt2 = max_dt
-            min_dt2 = min_dt
-
-            date_format = ''.join(self.DATE_FORMATS)
-
-            min_overlap = next(iter(self.STEP_SIZES.keys()))
 
         # find max sensible time overlap
         upper_overlap_limit = range / 2

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -395,7 +395,7 @@ class OWTimeSlice(widget.OWWidget):
         #   - set range for end dt (+ 1 timedelta)
         #   - set date format
         #   - set time overlap options
-        delta = data.time_delta
+        delta = data.time_delta.min
         range = max_dt - min_dt
         if isinstance(delta, Number):
             maximum = round(range / delta)
@@ -538,7 +538,7 @@ class OWTimeSlice(widget.OWWidget):
         self._set_disabled(False)
         slider.setHistogram(time_values)
         slider.setFormatter(var.repr_val)
-        slider.setScale(time_values.min(), time_values.max(), data.time_delta)
+        slider.setScale(time_values.min(), time_values.max(), data.time_delta.min)
         self.sliderValuesChanged(slider.minimumValue(), slider.maximumValue())
 
         self.date_from.setDateTimeRange(min_dt, max_dt)

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -350,6 +350,11 @@ class OWTimeSlice(widget.OWWidget):
         self.slider.repaint()
 
     def _set_disabled(self, is_disabled):
+        if is_disabled and self.play_timer.isActive():
+            self.play_button.click()
+            assert not self.play_timer.isActive()
+            assert not self.play_button.isChecked()
+
         for func in [self.date_from, self.date_to, self.step_backward,
                      self.play_button, self.step_forward,
                      self.controls.loop_playback, self.controls.step_size,

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -232,6 +232,14 @@ class OWTimeSlice(widget.OWWidget):
     def dteditValuesChanged(self, minTime, maxTime):
         minValue = self.slider.unscale(minTime)
         maxValue = self.slider.unscale(maxTime)
+        if minValue == maxValue:
+            # maxValue's range is minValue's range shifted by one
+            maxValue += 1
+            maxTime = self.slider.scale(maxValue)
+            to_dt = QDateTime.fromMSecsSinceEpoch(maxTime * 1000).toUTC()
+            with blockSignals(self.date_to):
+                self.date_to.setDateTime(to_dt)
+
         self._delta = max(1, (maxValue - minValue))
 
         if self.slider_values != (minValue, maxValue):
@@ -352,15 +360,16 @@ class OWTimeSlice(widget.OWWidget):
             range = max_dt - min_dt
             maximum = round(range / delta)
             timedelta = datetime.timedelta(milliseconds=delta * 1000)
-            max_dt += timedelta
+            min_dt2 = min_dt + timedelta
+            max_dt2 = max_dt + timedelta
             date_format = ''.join(self.DATE_FORMATS)
         elif delta:
             if delta[1] == 'day':
                 range = max_dt - min_dt
                 maximum = range.days / delta[0]
                 timedelta = datetime.timedelta(days=delta[0])
-                max_dt2 = max_dt + timedelta
                 min_dt2 = min_dt + timedelta
+                max_dt2 = max_dt + timedelta
                 date_format = ''.join(self.DATE_FORMATS[0:3])
             elif delta[1] == 'month':
                 months = (max_dt.year - min_dt.year) * 12 + \
@@ -380,7 +389,7 @@ class OWTimeSlice(widget.OWWidget):
                         month=max_dt.month + delta[0]
                     )
                 else:
-                    max_dt = max_dt.replace(
+                    max_dt2 = max_dt.replace(
                         year=max_dt.year + 1,
                         month=12 - min_dt.month + delta[0]
                     )
@@ -411,7 +420,7 @@ class OWTimeSlice(widget.OWWidget):
         self.sliderValuesChanged(slider.minimumValue(), slider.maximumValue())
 
         self.date_from.setDateTimeRange(min_dt, max_dt)
-        self.date_to.setDateTimeRange(min_dt, max_dt)
+        self.date_to.setDateTimeRange(min_dt2, max_dt2)
         self.date_from.setDisplayFormat(date_format)
         self.date_to.setDisplayFormat(date_format)
 

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -397,6 +397,12 @@ class OWTimeSlice(widget.OWWidget):
         self.date_from.setDisplayFormat(date_format)
         self.date_to.setDisplayFormat(date_format)
 
+        def format_time(i):
+            dt = QDateTime.fromMSecsSinceEpoch(i * 1000).toUTC()
+            return dt.toString(date_format)
+
+        self.slider.setFormatter(format_time)
+
 
 if __name__ == '__main__':
     from AnyQt.QtWidgets import QApplication

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -110,6 +110,8 @@ class OWTimeSlice(widget.OWWidget):
     class Outputs:
         subset = Output("Subset", Table)
 
+    settings_version = 2
+
     want_main_area = False
 
     class Error(widget.OWWidget.Error):
@@ -152,19 +154,19 @@ class OWTimeSlice(widget.OWWidget):
     loop_playback = settings.Setting(True)
     custom_step_size = settings.Setting(False)
     step_size = settings.Setting(next(iter(STEP_SIZES)))
-    playback_interval = settings.Setting(1000)
+    playback_interval = settings.Setting(1)
     slider_values = settings.Setting((0, .2 * MAX_SLIDER_VALUE))
 
     def __init__(self):
         super().__init__()
         self._delta = 0
         self.play_timer = QTimer(self,
-                                 interval=self.playback_interval,
+                                 interval=1000*self.playback_interval,
                                  timeout=self.play_single_step)
         slider = self.slider = Slider(Qt.Horizontal, self,
                                       minimum=0, maximum=self.MAX_SLIDER_VALUE,
                                       tracking=True,
-                                      playbackInterval=self.playback_interval,
+                                      playbackInterval=1000*self.playback_interval,
                                       valuesChanged=self.sliderValuesChanged,
                                       minimumValue=self.slider_values[0],
                                       maximumValue=self.slider_values[1])
@@ -551,6 +553,11 @@ class OWTimeSlice(widget.OWWidget):
             return dt.toString(date_format)
 
         self.slider.setFormatter(format_time)
+
+    @classmethod
+    def migrate_settings(cls, settings_, version):
+        if version < 2:
+            settings_["playback_interval"] /= 1000
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR rebases off #94.

##### Description of changes
- [x] Fix step size after adjusting the time window with a datetime edit (as opposed to grabbing and moving the sliders)
- [x] Smart selection (discretize according to time delta, constrict slider range according to `(max time - min time) / time delta`)
- [x] Make new selection on click(+drag) outside of the area between the sliders
- [x] Set a timer (using the specified interval) for sending data while moving the time window
- [x] Change Overlap Setting to Step size Setting

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
