### PR TITLE
timeseries: Unify As Timeseries and implicit conversion

### DIFF
--- a/doc/scripting.rst
+++ b/doc/scripting.rst
@@ -7,7 +7,7 @@ Start by importing the relevant objects:
 
 Let's load new :class:`Timeseries`, for example:
 
->>> data = Timeseries('airpassengers')
+>>> data = Timeseries.from_file('airpassengers')
 >>> np.set_printoptions(precision=1)
 
 :class:`Timeseries` object is just an :class:`Orange.data.Table` object with some
@@ -76,7 +76,7 @@ To decompose the time series into trend, seasonal and residual components,
 use :func:`seasonal_decompose` function:
 
 >>> from Orange.data import Domain
->>> passengers = Timeseries(Domain(['Air passengers'], source=data.domain), data)
+>>> passengers = Timeseries.from_table(Domain(['Air passengers'], source=data.domain), data)
 >>> decomposed = seasonal_decompose(passengers, model='multiplicative', period=12)
 >>> decomposed.domain
 [Air passengers (season. adj.), Air passengers (seasonal), Air passengers (trend), Air passengers (residual)]
@@ -84,7 +84,7 @@ use :func:`seasonal_decompose` function:
 To use this decomposed time series effectively, we just have to add back the
 time variable that was stripped in the first step above:
 
->>> ts = Timeseries(Timeseries.concatenate((data, decomposed)))
+>>> ts = Timeseries.concatenate((data, decomposed))
 >>> ts.time_variable = data.time_variable
 
 Just kidding. Use :func:`statsmodels.seasonal.seasonal_decompose` instead.
@@ -121,7 +121,7 @@ There are, as of yet, two models available: ARIMA and VAR. Both models have a
 common interface, so the usage of one is similar to the other. Let's look at an
 example. The data we model must have defined a class variable:
 
->>> data = Timeseries('airpassengers')
+>>> data = Timeseries.from_file('airpassengers')
 >>> data.domain
 [Month | Air passengers]
 >>> data.domain.class_var
@@ -195,7 +195,7 @@ example:
 
 >>> series = np.arange(100)
 >>> X = np.column_stack((series, np.roll(series, 1), np.roll(series, 3)))
->>> threecol = Timeseries(Domain.from_numpy(X), X)
+>>> threecol = Timeseries.from_numpy(Domain.from_numpy(X), X)
 >>> for lag, ante, cons in granger_causality(threecol, 10):
 ...     if lag > 1:
 ...         print('Series {cons} lags by {ante} by {lag} lags.'.format(**locals()))

--- a/orangecontrib/timeseries/datasources.py
+++ b/orangecontrib/timeseries/datasources.py
@@ -80,12 +80,14 @@ def finance_data(symbol,
         until = date.today()
 
     f = web.DataReader(symbol, 'yahoo', since, until)
-    data = Timeseries(table_from_frame(f))
+    data = Timeseries.from_data_table(table_from_frame(f))
 
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     attrs.remove('Adj Close')
-    data = Timeseries(Domain(attrs, [data.domain['Adj Close']], None, source=data.domain), data)
+    data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']],
+                                        None, source=data.domain),
+                                 data)
 
     data.name = symbol
     data.time_variable = data.domain['Date']

--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -335,7 +335,7 @@ def interpolate_timeseries(data, method='linear', multivariate=False):
             col[:first] = col[first]
             col[last:] = col[last]
 
-    ts = Timeseries(Domain(attrs, cvars, metas), X, Y, M)
+    ts = Timeseries.from_numpy(Domain(attrs, cvars, metas), X, Y, M)
     return ts
 
 
@@ -420,7 +420,7 @@ def seasonal_decompose(data, model='multiplicative', period=12, *, callback=None
         if callback:
             callback()
 
-    ts = Timeseries(Domain(attrs), np.column_stack(X))
+    ts = Timeseries.from_numpy(Domain(attrs), np.column_stack(X))
     return ts
 
 
@@ -533,12 +533,12 @@ def moving_transform(data, spec, fixed_wlen=0):
         dataY = dataY[::-1][::fixed_wlen][:n][::-1]
         dataM = dataM[::-1][::fixed_wlen][:n][::-1]
 
-    ts = Timeseries(Domain(data.domain.attributes + tuple(attrs),
-                           data.domain.class_vars,
-                           data.domain.metas),
-                    np.column_stack(
-                        (dataX, np.column_stack(X))) if X else dataX,
-                    dataY, dataM)
+    ts = Timeseries.from_numpy(Domain(data.domain.attributes + tuple(attrs),
+                                      data.domain.class_vars,
+                                      data.domain.metas),
+                               np.column_stack(
+                                   (dataX, np.column_stack(X))) if X else dataX,
+                               dataY, dataM)
     ts.time_variable = data.time_variable
     return ts
 

--- a/orangecontrib/timeseries/tests/test_correlation.py
+++ b/orangecontrib/timeseries/tests/test_correlation.py
@@ -4,7 +4,7 @@ import numpy as np
 from orangecontrib.timeseries import Timeseries, autocorrelation, partial_autocorrelation
 
 
-data = Timeseries('airpassengers')
+data = Timeseries.from_file('airpassengers')
 
 
 class TestAutocorrelation(unittest.TestCase):

--- a/orangecontrib/timeseries/tests/test_interpolation.py
+++ b/orangecontrib/timeseries/tests/test_interpolation.py
@@ -6,7 +6,7 @@ from orangecontrib.timeseries import Timeseries, interpolate_timeseries
 
 class TestInterpolation(unittest.TestCase):
     def setUp(self):
-        data = Timeseries('airpassengers')
+        data = Timeseries.from_file('airpassengers')
         data.Y[:2] = np.nan
         data.Y[10:15] = np.nan
         data.Y[-2:] = np.nan

--- a/orangecontrib/timeseries/tests/test_models.py
+++ b/orangecontrib/timeseries/tests/test_models.py
@@ -4,7 +4,7 @@ import numpy as np
 from orangecontrib.timeseries import Timeseries, ARIMA, VAR, model_evaluation
 
 
-data = Timeseries('airpassengers')
+data = Timeseries.from_file('airpassengers')
 
 
 class TestARIMA(unittest.TestCase):

--- a/orangecontrib/timeseries/tests/test_periodogram.py
+++ b/orangecontrib/timeseries/tests/test_periodogram.py
@@ -4,7 +4,7 @@ import numpy as np
 from orangecontrib.timeseries import Timeseries, periodogram, periodogram_nonequispaced
 
 
-data = Timeseries('airpassengers')
+data = Timeseries.from_file('airpassengers')
 
 
 class TestPeriodogram(unittest.TestCase):

--- a/orangecontrib/timeseries/tests/test_seasonal.py
+++ b/orangecontrib/timeseries/tests/test_seasonal.py
@@ -4,7 +4,7 @@ import numpy as np
 from orangecontrib.timeseries import Timeseries, seasonal_decompose
 
 
-data = Timeseries('airpassengers')
+data = Timeseries.from_file('airpassengers')
 
 
 class TestSeasonalDecompose(unittest.TestCase):

--- a/orangecontrib/timeseries/tests/test_timeseries.py
+++ b/orangecontrib/timeseries/tests/test_timeseries.py
@@ -11,7 +11,7 @@ from orangecontrib.timeseries.functions import timestamp, fromtimestamp
 class TestTimeseries(unittest.TestCase):
     def test_create_time_variable(self):
         table = Table("iris")
-        time_series = Timeseries(table)
+        time_series = Timeseries.from_data_table(table)
         id_1 = id(time_series.attributes)
         time_series.time_variable = time_series.domain.attributes[0]
         self.assertNotEqual(id_1, id(time_series.attributes))

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -20,15 +20,6 @@ class Timeseries(Table):
         self._interp_multivariate = False
         self._time_delta = None
 
-        # TODO replace all Timeseries constructor calls, remove this:
-        # Set default time variable to first TimeVariable
-        search = self.domain.attributes + self.domain.metas
-        try:
-            self.time_variable = next(var for var in search
-                                      if isinstance(var, TimeVariable))
-        except (StopIteration, AttributeError):
-            pass
-
     @classmethod
     def from_data_table(cls, table, detect_time_variable=False):
         if isinstance(table, Timeseries) \

--- a/orangecontrib/timeseries/widgets/_owmodel.py
+++ b/orangecontrib/timeseries/widgets/_owmodel.py
@@ -52,7 +52,8 @@ class OWBaseModel(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.update_model()
 
     def apply(self):

--- a/orangecontrib/timeseries/widgets/owaggregate.py
+++ b/orangecontrib/timeseries/widgets/owaggregate.py
@@ -190,7 +190,7 @@ class OWAggregate(widget.OWWidget):
             Y.append(ys)
             M.append(ms)
 
-        ts = Timeseries(
+        ts = Timeseries.from_numpy(
             Domain([data.time_variable] + attrs, cvars, metas),
             np.column_stack((times, np.row_stack(X))),
             np.array(Y),

--- a/orangecontrib/timeseries/widgets/owarimamodel.py
+++ b/orangecontrib/timeseries/widgets/owarimamodel.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWARIMAModel()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     domain = Domain(data.domain.attributes[:-1], data.domain.attributes[-1])
     data = Timeseries.from_numpy(domain, data.X[:, :-1], data.X[:, -1])
     ow.set_data(data)

--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWCorrelogram()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -70,7 +70,8 @@ class OWCorrelogram(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.Error.no_instances.clear()
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.all_attrs = []
         if data is None:
             self.plot.clear()

--- a/orangecontrib/timeseries/widgets/owdifference.py
+++ b/orangecontrib/timeseries/widgets/owdifference.py
@@ -97,8 +97,8 @@ class OWDifference(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.closeContext()
-        self.data = data = None if data is None else Timeseries.from_data_table(
-            data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         if data is not None:
             self.model[:] = [var for var in data.domain.variables
                              if var.is_continuous and var is not

--- a/orangecontrib/timeseries/widgets/owdifference.py
+++ b/orangecontrib/timeseries/widgets/owdifference.py
@@ -183,11 +183,11 @@ class OWDifference(widget.OWWidget):
             name = available_name(data.domain, template)
             attrs.append(ContinuousVariable(name))
 
-        ts = Timeseries(Domain(data.domain.attributes + tuple(attrs),
-                               data.domain.class_vars,
-                               data.domain.metas),
-                        np.column_stack((data.X, np.column_stack(X))),
-                        data.Y, data.metas)
+        ts = Timeseries.from_numpy(Domain(data.domain.attributes + tuple(attrs),
+                                          data.domain.class_vars,
+                                          data.domain.metas),
+                                   np.column_stack((data.X, np.column_stack(X))),
+                                   data.Y, data.metas)
         ts.time_variable = data.time_variable
         self.Outputs.time_series.send(ts)
 
@@ -198,16 +198,16 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWDifference()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:
         attrs.remove('Adj Close')
-        data = Timeseries(Domain(attrs,
-                                 [data.domain['Adj Close']],
-                                 None,
-                                 source=data.domain),
-                          data)
+        data = Timeseries.from_table(Domain(attrs,
+                                            [data.domain['Adj Close']],
+                                            None,
+                                            source=data.domain),
+                                     data)
 
     ow.set_data(data)
 

--- a/orangecontrib/timeseries/widgets/owgrangercausality.py
+++ b/orangecontrib/timeseries/widgets/owgrangercausality.py
@@ -69,7 +69,8 @@ class OWGrangerCausality(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.on_changed()
 
     def commit(self):

--- a/orangecontrib/timeseries/widgets/owgrangercausality.py
+++ b/orangecontrib/timeseries/widgets/owgrangercausality.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWGrangerCausality()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owinterpolate.py
+++ b/orangecontrib/timeseries/widgets/owinterpolate.py
@@ -53,7 +53,8 @@ class OWInterpolate(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
-        self.data = None if data is None else Timeseries.from_data_table(data)
+        self.data = None if data is None else \
+                    Timeseries.from_data_table(data, detect_time_variable=True)
         self.on_changed()
 
     def on_changed(self):

--- a/orangecontrib/timeseries/widgets/owinterpolate.py
+++ b/orangecontrib/timeseries/widgets/owinterpolate.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWInterpolate()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWLineChart()
 
-    airpassengers = Timeseries('airpassengers')
+    airpassengers = Timeseries.from_file('airpassengers')
     ow.set_data(airpassengers),
 
     msft = airpassengers.interp()

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -396,13 +396,17 @@ class OWLineChart(widget.OWWidget):
 
         # If the same data is updated, short circuit to just updating the chart,
         # retaining all panels and list view selections ...
-        if data is not None and self.data is not None and data.domain == self.data.domain:
-            self.data = Timeseries.from_data_table(data)
+        new_data = None if data is None else \
+                   Timeseries.from_data_table(data, detect_time_variable=True)
+        if new_data is not None and self.data is not None \
+                and new_data.domain == self.data.domain:
+            self.data = new_data
             for config in self.configs:
                 config.selection_changed()
             return
 
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         if data is None:
             self.varmodel.clear()
             self.chart.clear()

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -119,12 +119,14 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWModelEvaluation()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:
         attrs.remove('Adj Close')
-        data = Timeseries(Domain(attrs, [data.domain['Adj Close']], None, source=data.domain), data)
+        data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']], None,
+                                            source=data.domain),
+                                     data)
 
     ow.set_data(data)
     ow.set_model(ARIMA((1, 1, 1)), 1)

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -72,7 +72,8 @@ class OWModelEvaluation(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.on_changed()
 
     @Inputs.time_series_model

--- a/orangecontrib/timeseries/widgets/owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/owmovingtransform.py
@@ -215,12 +215,14 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWMovingTransform()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     attrs = [var.name for var in data.domain.attributes]
     if 'Adj Close' in attrs:
         # Make Adjusted Close a class variable
         attrs.remove('Adj Close')
-        data = Timeseries(Domain(attrs, [data.domain['Adj Close']], None, source=data.domain), data)
+        data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']], None,
+                                            source=data.domain),
+                                     data)
 
     ow.set_data(data)
 

--- a/orangecontrib/timeseries/widgets/owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/owmovingtransform.py
@@ -181,7 +181,8 @@ class OWMovingTransform(widget.OWWidget):
 
     @Inputs.time_series
     def set_data(self, data):
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.add_button.setDisabled(not len(getattr(data, 'domain', ())))
         self.table_model.clear()
         if data is not None:

--- a/orangecontrib/timeseries/widgets/owperiodogram.py
+++ b/orangecontrib/timeseries/widgets/owperiodogram.py
@@ -82,7 +82,8 @@ class OWPeriodogram(widget.OWWidget):
     @cache_clears(periodogram)
     @Inputs.time_series
     def set_data(self, data):
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
         self.all_attrs = []
         if data is None:
             self.plot.clear()

--- a/orangecontrib/timeseries/widgets/owperiodogram.py
+++ b/orangecontrib/timeseries/widgets/owperiodogram.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWPeriodogram()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/owseasonaladjustment.py
@@ -145,12 +145,14 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWSeasonalAdjustment()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     if not data.domain.class_var and 'Adj Close' in data.domain:
         # Make Adjusted Close a class variable
         attrs = [var.name for var in data.domain.attributes]
         attrs.remove('Adj Close')
-        data = Timeseries(Domain(attrs, [data.domain['Adj Close']], None, source=data.domain), data)
+        data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']], None,
+                                            source=data.domain),
+                                     data)
 
     ow.set_data(data)
 

--- a/orangecontrib/timeseries/widgets/owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/owseasonaladjustment.py
@@ -84,7 +84,8 @@ class OWSeasonalAdjustment(widget.OWWidget):
         self.Error.not_enough_instances.clear()
         self.data = None
         self.model.clear()
-        data = None if data is None else Timeseries.from_data_table(data)
+        data = None if data is None else \
+               Timeseries.from_data_table(data, detect_time_variable=True)
         if data is None:
             pass
         elif len(data) > 2:

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -336,7 +336,8 @@ class OWSpiralogram(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.Error.clear()
-        self.data = data = None if data is None else Timeseries.from_data_table(data)
+        self.data = data = None if data is None else \
+                           Timeseries.from_data_table(data, detect_time_variable=True)
 
         if data is None:
             self.commit()

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -29,10 +29,9 @@ class OWTableToTimeseries(widget.OWWidget):
     selected_attr = settings.Setting('')
     autocommit = settings.Setting(True)
 
-    class Error(widget.OWWidget.Error):
+    class Information(widget.OWWidget.Information):
         nan_times = widget.Msg('Some values of chosen sequential attribute '
-                               '"{}" are NaN, which makes the values '
-                               'impossible to sort')
+                               '"{}" are NaN, and have been omitted')
 
     def __init__(self):
         self.data = None
@@ -63,6 +62,7 @@ class OWTableToTimeseries(widget.OWWidget):
         if self.data is None:
             self.commit()
             return
+
         if data.domain.has_continuous_attributes():
             vars = [var for var in data.domain.variables if var.is_time] + \
                    [var for var in data.domain.metas if var.is_time] + \
@@ -79,45 +79,23 @@ class OWTableToTimeseries(widget.OWWidget):
 
     def commit(self):
         data = self.data
-        self.Error.clear()
+        self.Information.clear()
         if data is None or (self.selected_attr not in data.domain and not self.radio_sequential):
             self.Outputs.time_series.send(None)
             return
 
-        attrs = data.domain.attributes
-        cvars = data.domain.class_vars
-        metas = data.domain.metas
-        X = data.X
-        Y = np.column_stack((data.Y,))  # make 2d
-        M = data.metas
-
-        # Set sequence attribute
         if self.radio_sequential:
-            for i in chain(('',), range(10)):
-                name = '__seq__' + str(i)
-                if name not in data.domain:
-                    break
-            time_var = ContinuousVariable(name)
-            attrs = attrs.__class__((time_var,)) + attrs
-            X = np.column_stack((np.arange(1, len(data) + 1), X))
-            data = Table(Domain(attrs, cvars, metas), X, Y, M)
+            ts = Timeseries.make_timeseries_from_sequence(data)
         else:
-            # Or make a sequence attribute one of the existing attributes
-            # and sort all values according to it
+            ts = Timeseries.make_timeseries_from_continuous_var(data,
+                                                                self.selected_attr)
+            # Check if NaNs were present in data
             time_var = data.domain[self.selected_attr]
             values = Table.from_table(Domain([], [], [time_var]),
                                       source=data).metas.ravel()
             if np.isnan(values).any():
-                self.Error.nan_times(time_var.name)
-                self.Outputs.time_series.send(None)
-                return
-            ordered = np.argsort(values)
-            if (ordered != np.arange(len(ordered))).any():
-                data = data[ordered]
+                self.Information.nan_times(time_var.name)
 
-        ts = Timeseries(data.domain, data)
-        # TODO: ensure equidistant
-        ts.time_variable = time_var
         self.Outputs.time_series.send(ts)
 
 

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWTableToTimeseries()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/owvarmodel.py
+++ b/orangecontrib/timeseries/widgets/owvarmodel.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     a = QApplication([])
     ow = OWVARModel()
 
-    data = Timeseries('airpassengers')
+    data = Timeseries.from_file('airpassengers')
     ow.set_data(data)
 
     ow.show()

--- a/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
@@ -20,7 +20,7 @@ class TestCorrelogramWidget(WidgetTest):
         Now interpolation is skipped.
         GH-27
         """
-        time_series = Timeseries(
+        time_series = Timeseries.from_list(
             Domain(attributes=[ContinuousVariable("a"), ContinuousVariable("b")]),
             list(zip(list(range(5)), list(range(5))))
         )
@@ -38,7 +38,7 @@ class TestCorrelogramWidget(WidgetTest):
             self.send_signal(self.widget.Inputs.time_series, data)
             self.assertEqual(self.widget.Error.no_instances.is_shown(), is_shown)
 
-        ts = Timeseries("airpassengers")
+        ts = Timeseries.from_file("airpassengers")
 
         self.assertFalse(self.widget.Error.no_instances.is_shown())
         for data, is_shown in ((ts[:1], True), (ts, False), (ts[:0], True), (None, False)):

--- a/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
@@ -16,7 +16,7 @@ class TestOWLineChart(WidgetTest):
         GH-46
         """
         w = self.widget
-        time_series = Timeseries("airpassengers")
+        time_series = Timeseries.from_file("airpassengers")
         self.send_signal(w.Inputs.time_series, time_series)
         self.send_signal(w.Inputs.time_series, None)
         self.send_signal(w.Inputs.forecast, time_series, 1)

--- a/orangecontrib/timeseries/widgets/tests/test_owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owmodelevaluation.py
@@ -18,7 +18,7 @@ class TestOWModelEvaluation(WidgetTest):
         """
         w = self.widget
         table = Table("housing")
-        time_series = Timeseries(table)
+        time_series = Timeseries.from_data_table(table)
         model = ARIMA((2, 5, 1), 0)
         self.assertFalse(w.Warning.model_not_appropriate.is_shown())
         self.send_signal(w.Inputs.time_series, time_series)

--- a/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
@@ -18,9 +18,9 @@ class TestOWSeasonalAdjustment(WidgetTest):
         GH-35
         """
         w = self.widget
-        table = Table("iris")
+        table = Table.from_file("iris")
         table.X[1, 0] = -1
-        time_series = Timeseries(table)
+        time_series = Timeseries.from_data_table(table)
         w.decomposition = 1
         w.autocommit = True
         self.assertFalse(w.Error.seasonal_decompose_fail.is_shown())
@@ -36,7 +36,7 @@ class TestOWSeasonalAdjustment(WidgetTest):
         GH-38
         """
         w = self.widget
-        time_series = Timeseries(Table("iris")[::30])
+        time_series = Timeseries.from_data_table(Table("iris")[::30])
         self.assertEqual(w.n_periods, 12)
         self.send_signal(w.Inputs.time_series, time_series)
         self.assertEqual(w.n_periods, 4)
@@ -47,7 +47,7 @@ class TestOWSeasonalAdjustment(WidgetTest):
         GH-38
         """
         w = self.widget
-        time_series = Timeseries(Table("iris")[:2])
+        time_series = Timeseries.from_data_table(Table("iris")[:2])
         self.assertFalse(w.Error.not_enough_instances.is_shown())
         self.send_signal(w.Inputs.time_series, time_series)
         self.assertTrue(w.Error.not_enough_instances.is_shown())
@@ -60,7 +60,7 @@ class TestOWSeasonalAdjustment(WidgetTest):
         """
         w = self.widget
         w.autocommit = True
-        time_series = Timeseries(Table("iris"))
+        time_series = Timeseries.from_data_table(Table("iris"))
         self.send_signal(w.Inputs.time_series, time_series)
         selmodel = w.view.selectionModel()
         selmodel.select(w.model.index(0), selmodel.Select)

--- a/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
@@ -18,13 +18,12 @@ class TestOWSeasonalAdjustment(WidgetTest):
         GH-35
         """
         w = self.widget
-        table = Table.from_file("iris")
-        table.X[1, 0] = -1
-        time_series = Timeseries.from_data_table(table)
+        table = Timeseries.from_file("iris")
+        table.X[1, 1] = -1
         w.decomposition = 1
         w.autocommit = True
         self.assertFalse(w.Error.seasonal_decompose_fail.is_shown())
-        self.send_signal(w.Inputs.time_series, time_series)
+        self.send_signal(w.Inputs.time_series, table)
         self.widget.view.selectAll()
         self.assertTrue(w.Error.seasonal_decompose_fail.is_shown())
         self.send_signal(w.Inputs.time_series, None)

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -35,13 +35,13 @@ class TestAsTimeSeriesWidget(WidgetTest):
         """
         w = self.widget
         data = Table("iris")[:2]
-        self.assertFalse(w.Error.nan_times.is_shown())
+        self.assertFalse(w.Information.nan_times.is_shown())
         self.send_signal(w.Inputs.data, data)
-        self.assertFalse(w.Error.nan_times.is_shown())
+        self.assertFalse(w.Information.nan_times.is_shown())
         self.assertIsInstance(self.get_output(w.Outputs.time_series), Timeseries)
         data.X[:, 0] = np.nan
         self.send_signal(w.Inputs.data, data)
-        self.assertTrue(w.Error.nan_times.is_shown())
+        self.assertTrue(w.Information.nan_times.is_shown())
         self.assertIsNone(self.get_output(w.Outputs.time_series))
 
     def test_non_cont_sequental(self):


### PR DESCRIPTION
##### Issue
#85 


##### Description of changes
Moved some code from As Timeseries to static functions in `timeseries.py`, so the same code is invoked when using As Timeseries and when connecting Data directly to a timeseries widget.

Timeseries are now always sorted.

NaN values in a continuous attribute that's being used as a time attribute are silently removed in implicit conversion from data table, and coupled with an Information message in the As Timeseries widget.

However, I didn't get the chance to fully test this – Line Chart has been crashing with a TimeoutError for me.

I think the 5 lines at `orangecontrib/timeseries/timeseries.py:23` should be thrown out now that `from_data_table` is more comprehensive, but I left it in (for now), in the interest of backwards compatibility.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
