### PR TITLE
As Timeseries: support dates in metas

### DIFF
--- a/orangecontrib/timeseries/tests/test_timeseries.py
+++ b/orangecontrib/timeseries/tests/test_timeseries.py
@@ -16,6 +16,13 @@ class TestTimeseries(unittest.TestCase):
         time_series.time_variable = time_series.domain.attributes[0]
         self.assertNotEqual(id_1, id(time_series.attributes))
 
+    def test_make_timeseries_from_continuous_var(self):
+        table = Table.from_url("http://file.biolab.si/datasets/slovenian-national-assembly-eng.tab")
+        time_series = Timeseries.make_timeseries_from_continuous_var(table,
+                                                                     'date of birth')
+        self.assertEqual(time_series.time_variable.name, 'date of birth')
+        self.assertTrue(time_series.time_variable in time_series.domain.metas)
+
 
 class TestTimestamp(unittest.TestCase):
     def test_timestamp(self):

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -178,7 +178,7 @@ class Timeseries(Table):
         # Make a sequence attribute from one of the existing attributes,
         # and sort all values according to it
         time_var = table.domain[attr_name]
-        values = table.get_column_view(time_var)[0]
+        values = table.get_column_view(time_var)[0].astype(float)
         # Filter out NaNs
         nans = np.isnan(values)
         if nans.all():

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -63,14 +63,14 @@ class OWTableToTimeseries(widget.OWWidget):
             self.commit()
             return
 
-        if data.domain.has_continuous_attributes():
+        if data.domain.has_continuous_attributes(include_metas=True):
             vars = [var for var in data.domain.variables if var.is_time] + \
                    [var for var in data.domain.metas if var.is_time] + \
                    [var for var in data.domain.variables
                     if var.is_continuous and not var.is_time] + \
                    [var for var in data.domain.metas if var.is_continuous and
                     not var.is_time]
-            self.attrs_model.wrap(vars)
+            self.attrs_model[:] = vars
             self.selected_attr = data.time_variable.name if getattr(data, 'time_variable', False) else vars[0].name
         self.on_changed()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
As Timeseries doesn't consider dates in meta attributes.

##### Description of changes
Enable support for dates in metas (e.g. Twitter widget puts dates in metas).
Always cast time values as floats.

TODO: tests

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
