### PR TITLE
[WIP] OWTimeSlice: UX Fixup

### DIFF
--- a/orangecontrib/timeseries/widgets/_rangeslider.py
+++ b/orangecontrib/timeseries/widgets/_rangeslider.py
@@ -442,7 +442,7 @@ class ViolinSlider(RangeSlider):
 
     def _testHandleCollision(self, position):
         pos = self._pixelPosToRangeValue(self._pick(position))
-        delta = min(10, max(5, (self.maximum() - self.minimum()) // 25))
+        delta = (self.maximum() - self.minimum()) // 20
         diffs = []
         for h in [self._min_position, self._max_position]:
             if h in range(pos - delta, pos + delta + 1):

--- a/orangecontrib/timeseries/widgets/icons/TimeSlice-pause.svg
+++ b/orangecontrib/timeseries/widgets/icons/TimeSlice-pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" fill="white"/></svg>

--- a/orangecontrib/timeseries/widgets/icons/TimeSlice-play.svg
+++ b/orangecontrib/timeseries/widgets/icons/TimeSlice-play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M8 5v14l11-7z" fill="white"/></svg>

--- a/orangecontrib/timeseries/widgets/icons/TimeSlice-step_backward.svg
+++ b/orangecontrib/timeseries/widgets/icons/TimeSlice-step_backward.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg>

--- a/orangecontrib/timeseries/widgets/icons/TimeSlice-step_forward.svg
+++ b/orangecontrib/timeseries/widgets/icons/TimeSlice-step_forward.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -173,10 +173,10 @@ class OWTimeSlice(widget.OWWidget):
                                       minimumValue=self.slider_values[0],
                                       maximumValue=self.slider_values[1])
         slider.setShowText(False)
-        box = gui.vBox(self.controlArea, 'Time Slice')
-        box.layout().addWidget(slider)
+        selectBox = gui.vBox(self.controlArea, 'Select a Time Range')
+        selectBox.layout().addWidget(slider)
 
-        hbox = gui.hBox(box)
+        dtBox = gui.hBox(selectBox)
 
         kwargs = dict(calendarPopup=True,
                       displayFormat=' '.join(self.DATE_FORMATS),
@@ -206,42 +206,44 @@ class OWTimeSlice(widget.OWWidget):
             lambda: date_to.calendarWidget().repaint()
         )
 
-        hbox.layout().addStretch(100)
-        hbox.layout().addWidget(date_from)
-        hbox.layout().addWidget(QLabel(' – '))
-        hbox.layout().addWidget(date_to)
-        hbox.layout().addStretch(100)
+        dtBox.layout().addStretch(100)
+        dtBox.layout().addWidget(date_from)
+        dtBox.layout().addWidget(QLabel(' – '))
+        dtBox.layout().addWidget(date_to)
+        dtBox.layout().addStretch(100)
 
-        vbox = gui.vBox(self.controlArea, 'Step / Play Through')
-        gui.checkBox(vbox, self, 'loop_playback',
+        stepThroughBox = gui.vBox(self.controlArea, 'Step/Play Through')
+        gui.rubber(stepThroughBox)
+        gui.checkBox(stepThroughBox, self, 'loop_playback',
                      label='Loop playback')
-        hbox = gui.hBox(vbox)
-        gui.checkBox(hbox, self, 'custom_step_size',
+        customStepBox = gui.hBox(stepThroughBox)
+        gui.checkBox(customStepBox, self, 'custom_step_size',
                      label='Custom step size:',
                      toolTip='If not chosen, the active interval moves forward '
                              '(backward), stepping in increments of its own size.')
-        self.stepsize_combobox = gui.comboBox(hbox, self, 'step_size',
+        self.stepsize_combobox = gui.comboBox(customStepBox, self, 'step_size',
                                               items=tuple(self.STEP_SIZES.keys()),
                                               sendSelectedValue=True)
-        hbox = gui.hBox(vbox)
-        self.step_backward = gui.button(hbox, self, '⏮',
+        playBox = gui.hBox(stepThroughBox)
+        gui.rubber(stepThroughBox)
+        self.step_backward = gui.button(playBox, self, '⏮',
                                         callback=lambda: self.play_single_step(backward=True),
                                         autoDefault=False)
-        self.play_button = gui.button(hbox, self, '▶',
+        self.play_button = gui.button(playBox, self, '▶️',
                                       callback=self.playthrough,
                                       toggleButton=True, default=True)
-        self.step_forward = gui.button(hbox, self, '⏭',
+        self.step_forward = gui.button(playBox, self, '⏭',
                                        callback=self.play_single_step,
                                        autoDefault=False)
 
-        vbox = gui.vBox(self.controlArea, 'Playback/Tracking interval')
-        vbox.setToolTip('In milliseconds, set the delay for playback and '
-                        'for sending data upon manually moving the interval.')
+        intervalBox = gui.vBox(self.controlArea, 'Playback/Tracking interval')
+        intervalBox.setToolTip('In milliseconds, set the delay for playback and '
+                               'for sending data upon manually moving the interval.')
 
         def set_intervals():
             self.play_timer.setInterval(1000 * self.playback_interval)
             self.slider.tracking_timer.setInterval(1000 * self.playback_interval)
-        gui.valueSlider(vbox, self, 'playback_interval',
+        gui.valueSlider(intervalBox, self, 'playback_interval',
                         label='Delay:', labelFormat='%.2g sec',
                         values=self.DELAY_VALUES,
                         callback=set_intervals)
@@ -307,10 +309,10 @@ class OWTimeSlice(widget.OWWidget):
 
         if playing:
             self.play_timer.start()
-            self.play_button.setText('▮▮')
+            self.play_button.setText('⏸')
         else:
             self.play_timer.stop()
-            self.play_button.setText('▶')
+            self.play_button.setText('▶️')
 
         # hotfix
         self.repaint()

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -212,13 +212,17 @@ class OWTimeSlice(widget.OWWidget):
         dtBox.layout().addWidget(date_to)
         dtBox.layout().addStretch(100)
 
-        stepThroughBox = gui.vBox(self.controlArea, 'Step/Play Through')
+        hCenterBox = gui.hBox(self.controlArea)
+        gui.rubber(hCenterBox)
+        vControlsBox = gui.vBox(hCenterBox)
+
+        stepThroughBox = gui.vBox(vControlsBox, 'Step/Play Through')
         gui.rubber(stepThroughBox)
         gui.checkBox(stepThroughBox, self, 'loop_playback',
                      label='Loop playback')
         customStepBox = gui.hBox(stepThroughBox)
         gui.checkBox(customStepBox, self, 'custom_step_size',
-                     label='Custom step size:',
+                     label='Custom step size: ',
                      toolTip='If not chosen, the active interval moves forward '
                              '(backward), stepping in increments of its own size.')
         self.stepsize_combobox = gui.comboBox(customStepBox, self, 'step_size',
@@ -236,7 +240,7 @@ class OWTimeSlice(widget.OWWidget):
                                        callback=self.play_single_step,
                                        autoDefault=False)
 
-        intervalBox = gui.vBox(self.controlArea, 'Playback/Tracking interval')
+        intervalBox = gui.vBox(vControlsBox, 'Playback/Tracking interval')
         intervalBox.setToolTip('In milliseconds, set the delay for playback and '
                                'for sending data upon manually moving the interval.')
 
@@ -248,6 +252,7 @@ class OWTimeSlice(widget.OWWidget):
                         values=self.DELAY_VALUES,
                         callback=set_intervals)
 
+        gui.rubber(hCenterBox)
         gui.rubber(self.controlArea)
         self._set_disabled(True)
 

--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -4,9 +4,11 @@ from contextlib import contextmanager
 import operator
 from collections import OrderedDict
 from numbers import Number
+from os.path import join, dirname
 
 from AnyQt.QtWidgets import QLabel, QDateTimeEdit
 from AnyQt.QtCore import QDateTime, Qt, QSize, QTimer
+from AnyQt.QtGui import QIcon
 
 from Orange.data import Table, TimeVariable
 from Orange.widgets import widget, gui, settings
@@ -229,17 +231,28 @@ class OWTimeSlice(widget.OWWidget):
                                               items=tuple(self.STEP_SIZES.keys()),
                                               sendSelectedValue=True)
         playBox = gui.hBox(stepThroughBox)
+        gui.rubber(playBox)
         gui.rubber(stepThroughBox)
-        self.step_backward = gui.button(playBox, self, '⏮',
+
+        self._play_icon = QIcon(join(dirname(__file__), 'icons', 'TimeSlice-play.svg'))
+        self._back_icon = QIcon(join(dirname(__file__), 'icons', 'TimeSlice-step_backward.svg'))
+        self._forward_icon = QIcon(join(dirname(__file__), 'icons', 'TimeSlice-step_forward.svg'))
+        self._pause_icon = QIcon(join(dirname(__file__), 'icons', 'TimeSlice-pause.svg'))
+
+        self.step_backward = gui.button(playBox, self, '',
                                         callback=lambda: self.play_single_step(backward=True),
                                         autoDefault=False)
-        self.play_button = gui.button(playBox, self, '▶️',
+        self.step_backward.setIcon(self._back_icon)
+        self.play_button = gui.button(playBox, self, '',
                                       callback=self.playthrough,
                                       toggleButton=True, default=True)
-        self.step_forward = gui.button(playBox, self, '⏭',
+        self.play_button.setIcon(self._play_icon)
+        self.step_forward = gui.button(playBox, self, '',
                                        callback=self.play_single_step,
                                        autoDefault=False)
+        self.step_forward.setIcon(self._forward_icon)
 
+        gui.rubber(playBox)
         intervalBox = gui.vBox(vControlsBox, 'Playback/Tracking interval')
         intervalBox.setToolTip('In milliseconds, set the delay for playback and '
                                'for sending data upon manually moving the interval.')
@@ -314,10 +327,10 @@ class OWTimeSlice(widget.OWWidget):
 
         if playing:
             self.play_timer.start()
-            self.play_button.setText('⏸')
+            self.play_button.setIcon(self._pause_icon)
         else:
             self.play_timer.stop()
-            self.play_button.setText('▶️')
+            self.play_button.setIcon(self._play_icon)
 
         # hotfix
         self.repaint()


### PR DESCRIPTION
##### Description of changes
- Standardize handle hitbox
- Rename stuff
- Restrict expansion of control area (Is there an easier way of achieving this?)

I couldn't get the checkboxes to align, and there's more space below the controls within a box than above. With the fixed control area size, this has now become more apparent. I suppose this is an orange-widget-base issue though?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
