### PR TITLE
[FIX] Line chart: Show zeros after change from logarithmic to linear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: python
 dist: xenial # trusty doesn't support Py3.7
 
+addons:
+    apt:
+        packages:
+            - libxkbcommon-x11-0  # for PyQt 5.12
+            - libxcb-icccm4
+            - libxcb-image0
+            - libxcb-keysyms1
+            - libxcb-randr0
+            - libxcb-render-util0
+            - libxcb-xinerama0
+
 cache:
     apt: true
     pip: true

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -308,7 +308,20 @@ class Highstock(Highchart):
         ''' % dict(ax=ax, type='logarithmic' if is_logarithmic else 'linear',
                    negative='true' if is_logarithmic else 'false',
                    tick=1 if is_logarithmic else 'undefined'))
-
+        if not is_logarithmic:
+            # it is a workaround for Highcharts issue - Highcharts do not
+            # un-mark data as null when changing graph from logarithmic to
+            # linear
+            self.evalJS(
+                '''
+                s = chart.get('%(ax)s').series;
+                s.forEach(function(series) {
+                    series.data.forEach(function(point) {
+                        point.update({'isNull': false});
+                    });
+                });
+                ''' % dict(ax=ax)
+            )
 
     def setType(self, ax, type):
         step, type = ('true', 'line') if type == 'step line' else ('false', type)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-timeseries/issues/104

##### Description of changes
Adde a workaround for a Highchart issue. Highchart marks nonpositive values as null when changing to logarithmic and does not un-mark them.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
