### PR TITLE
Don't detect continuous var as time var

### DIFF
--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -78,7 +78,7 @@ class Timeseries(Table):
         self.time_delta = None
 
     @classmethod
-    def from_data_table(cls, table, detect_time_variable=False):
+    def from_data_table(cls, table, fallback_sequential=False):
         if isinstance(table, Timeseries) \
                 and table.time_variable is not None \
                 and table.time_delta is not None:
@@ -103,51 +103,45 @@ class Timeseries(Table):
         except (StopIteration, AttributeError):
             pass
 
-        if not detect_time_variable:
+        if not fallback_sequential:
+            # Make a timeseries without a time variable
             ts = super(Timeseries, cls).from_table(table.domain, table)
             return ts
 
-        # Is there a continuous variable we can use?
-        try:
-            continuous_variable = next(var for var in search
-                                       if var.is_continuous)
-            return cls.make_timeseries_from_continuous_var(table, continuous_variable)
-        except (StopIteration, AttributeError):
-            pass
         # Fallback to sequential
         return cls.make_timeseries_from_sequence(table)
 
     @classmethod
-    def from_domain(cls, *args, detect_time_variable=False, **kwargs):
+    def from_domain(cls, *args, fallback_sequential=False, **kwargs):
         table = Table.from_domain(*args, **kwargs)
-        return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+        return cls.from_data_table(table, fallback_sequential=fallback_sequential)
 
     @classmethod
-    def from_table(cls, domain, source, *args, detect_time_variable=False, **kwargs):
+    def from_table(cls, domain, source, *args, fallback_sequential=False, **kwargs):
         if not isinstance(source, Timeseries):
             table = Table.from_table(domain, source, *args, **kwargs)
-            return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+            return cls.from_data_table(table, fallback_sequential=fallback_sequential)
         return super().from_table(domain, source, *args, **kwargs)
 
     @classmethod
-    def from_numpy(cls, *args, detect_time_variable=False, **kwargs):
+    def from_numpy(cls, *args, fallback_sequential=False, **kwargs):
         table = Table.from_numpy(*args, **kwargs)
-        return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+        return cls.from_data_table(table, fallback_sequential=fallback_sequential)
 
     @classmethod
-    def from_list(cls, *args, detect_time_variable=False, **kwargs):
+    def from_list(cls, *args, fallback_sequential=False, **kwargs):
         table = Table.from_list(*args, **kwargs)
-        return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+        return cls.from_data_table(table, fallback_sequential=fallback_sequential)
 
     @classmethod
-    def from_file(cls, *args, detect_time_variable=False, **kwargs):
+    def from_file(cls, *args, fallback_sequential=False, **kwargs):
         table = Table.from_file(*args, **kwargs)
-        return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+        return cls.from_data_table(table, fallback_sequential=fallback_sequential)
 
     @classmethod
-    def from_url(cls, *args, detect_time_variable=False, **kwargs):
+    def from_url(cls, *args, fallback_sequential=False, **kwargs):
         table = Table.from_url(*args, **kwargs)
-        return cls.from_data_table(table, detect_time_variable=detect_time_variable)
+        return cls.from_data_table(table, fallback_sequential=fallback_sequential)
 
     @classmethod
     def make_timeseries_from_sequence(cls, table):

--- a/orangecontrib/timeseries/widgets/_owmodel.py
+++ b/orangecontrib/timeseries/widgets/_owmodel.py
@@ -53,7 +53,7 @@ class OWBaseModel(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         self.update_model()
 
     def apply(self):

--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -71,7 +71,7 @@ class OWCorrelogram(widget.OWWidget):
     def set_data(self, data):
         self.Error.no_instances.clear()
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         self.all_attrs = []
         if data is None:
             self.plot.clear()

--- a/orangecontrib/timeseries/widgets/owdifference.py
+++ b/orangecontrib/timeseries/widgets/owdifference.py
@@ -98,7 +98,7 @@ class OWDifference(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         if data is not None:
             self.model[:] = [var for var in data.domain.variables
                              if var.is_continuous and var is not

--- a/orangecontrib/timeseries/widgets/owgrangercausality.py
+++ b/orangecontrib/timeseries/widgets/owgrangercausality.py
@@ -70,7 +70,7 @@ class OWGrangerCausality(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         self.on_changed()
 
     def commit(self):

--- a/orangecontrib/timeseries/widgets/owinterpolate.py
+++ b/orangecontrib/timeseries/widgets/owinterpolate.py
@@ -54,7 +54,7 @@ class OWInterpolate(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.data = None if data is None else \
-                    Timeseries.from_data_table(data, detect_time_variable=True)
+                    Timeseries.from_data_table(data, fallback_sequential=True)
         self.on_changed()
 
     def on_changed(self):

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -397,7 +397,7 @@ class OWLineChart(widget.OWWidget):
         # If the same data is updated, short circuit to just updating the chart,
         # retaining all panels and list view selections ...
         new_data = None if data is None else \
-                   Timeseries.from_data_table(data, detect_time_variable=True)
+                   Timeseries.from_data_table(data, fallback_sequential=True)
         if new_data is not None and self.data is not None \
                 and new_data.domain == self.data.domain:
             self.data = new_data
@@ -406,7 +406,7 @@ class OWLineChart(widget.OWWidget):
             return
 
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         if data is None:
             self.varmodel.clear()
             self.chart.clear()

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -73,7 +73,7 @@ class OWModelEvaluation(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         self.on_changed()
 
     @Inputs.time_series_model

--- a/orangecontrib/timeseries/widgets/owmovingtransform.py
+++ b/orangecontrib/timeseries/widgets/owmovingtransform.py
@@ -249,7 +249,7 @@ class OWMovingTransform(widget.OWWidget):
             self.data = None
             self.var_model.clear()
         else:
-            self.data = Timeseries.from_data_table(data, detect_time_variable=True)
+            self.data = Timeseries.from_data_table(data, fallback_sequential=True)
             self.var_model[:] = [
                 var for var in self.data.domain.variables
                 if var.is_continuous and var is not self.data.time_variable]

--- a/orangecontrib/timeseries/widgets/owperiodogram.py
+++ b/orangecontrib/timeseries/widgets/owperiodogram.py
@@ -82,7 +82,7 @@ class OWPeriodogram(widget.OWWidget):
     @Inputs.time_series
     def set_data(self, data):
         self.data = data = None if data is None else \
-                           Timeseries.from_data_table(data, detect_time_variable=True)
+                           Timeseries.from_data_table(data, fallback_sequential=True)
         self.all_attrs = []
         if data is None:
             self.plot.clear()

--- a/orangecontrib/timeseries/widgets/owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/owseasonaladjustment.py
@@ -85,7 +85,7 @@ class OWSeasonalAdjustment(widget.OWWidget):
         self.data = None
         self.model.clear()
         data = None if data is None else \
-               Timeseries.from_data_table(data, detect_time_variable=True)
+               Timeseries.from_data_table(data, fallback_sequential=True)
         if data is None:
             pass
         elif len(data) > 2:

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -339,7 +339,7 @@ class OWSpiralogram(widget.OWWidget):
     def set_data(self, data):
         self.Error.clear()
         self.data = data = None if data is None else \
-            Timeseries.from_data_table(data, detect_time_variable=True)
+            Timeseries.from_data_table(data, fallback_sequential=True)
 
         if data is None:
             self.commit()


### PR DESCRIPTION
##### Description of changes
The `detect_time_var` functionality has been changed to `fallback_sequential`, meaning that, if there is no TimeVariable, sequential ordering is assumed instead of the first continuous variable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
