### PR TITLE
timeseries: Drop timedelta 0

### DIFF
--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -29,6 +29,9 @@ class TimeDelta:
             return
 
         deltas = list(np.sort(np.unique(np.diff(self.time_values))))
+        # in case several rows fall on the same datetime, remove the zero
+        if deltas[0] == 0:
+            deltas = deltas[1:]
         # TODO detect multiple days/months/years
         for i, d in enumerate(deltas[:]):
             if d in self._SPAN_DAY:

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -28,7 +28,7 @@ class TimeDelta:
             self.min = None
             return
 
-        deltas = list(np.sort(np.unique(np.diff(self.time_values))))
+        deltas = list(np.sort(np.unique(np.diff(np.sort(self.time_values)))))
         # in case several rows fall on the same datetime, remove the zero
         if deltas[0] == 0:
             deltas = deltas[1:]


### PR DESCRIPTION
##### Issue
Fixes #115 

##### Description of changes
When faced with data in which two rows fall on the same datetime, don't set the minimum timedelta as zero.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
