### PR TITLE
OWTimeSlice: Cast datetime to utc before setting it to QDateTimeEdit

### DIFF
--- a/orangecontrib/timeseries/widgets/owtimeslice.py
+++ b/orangecontrib/timeseries/widgets/owtimeslice.py
@@ -7,7 +7,7 @@ from numbers import Number
 from os.path import join, dirname
 
 from AnyQt.QtWidgets import QLabel, QDateTimeEdit
-from AnyQt.QtCore import QDateTime, Qt, QSize, QTimer
+from AnyQt.QtCore import QDateTime, Qt, QSize, QTimer, QTimeZone
 from AnyQt.QtGui import QIcon
 
 from Orange.data import Table, TimeVariable
@@ -560,8 +560,13 @@ class OWTimeSlice(widget.OWWidget):
         slider.setScale(time_values.min(), time_values.max(), data.time_delta.min)
         self.sliderValuesChanged(slider.minimumValue(), slider.maximumValue())
 
-        self.date_from.setDateTimeRange(min_dt, max_dt)
-        self.date_to.setDateTimeRange(min_dt2, max_dt2)
+        def utc_dt(dt):
+            qdt = QDateTime(dt)
+            qdt.setTimeZone(QTimeZone.utc())
+            return qdt
+
+        self.date_from.setDateTimeRange(utc_dt(min_dt), utc_dt(max_dt))
+        self.date_to.setDateTimeRange(utc_dt(min_dt2), utc_dt(max_dt2))
         self.date_from.setDisplayFormat(date_format)
         self.date_to.setDisplayFormat(date_format)
 


### PR DESCRIPTION
##### Issue
Fixes #101


##### Description of changes
Python datetime objects are supposed to be usable wherever a QDateTime object is expected. It seems that although the python datetime has its timezone set to UTC, when passed as a QDateTime, this is forgotten. This PR constructs a QDateTime manually and sets the timezone.

Sidenote: I've seen in other widgets the use of `data.time_variable.timezone`. This isn't used in time slice, everything is cast to UTC. Does this miss some edge cases? (@ajdapretnar, do you know?)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
