### PR TITLE
Fix TimeoutError in Spiralogram

### DIFF
--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -222,7 +222,7 @@ def partial_autocorrelation(x, *args, nlags=None, method='ldb', **kwargs):
         A 1D signal.
     nlags: int
         The number of lags to calculate the correlation for
-        (default: min(600, len(x)))
+        (default: min(len(x)//2 - 1, len(x) - 1))
     args, kwargs
         As accepted by `statsmodels.tsa.stattools.pacf`.
 
@@ -235,7 +235,7 @@ def partial_autocorrelation(x, *args, nlags=None, method='ldb', **kwargs):
     """
     from statsmodels.tsa.stattools import pacf
     if nlags is None:
-        nlags = min(1000, len(x) - 1)
+        nlags = min(len(x)//2 - 1, len(x) - 1)
     corr = pacf(x, *args, nlags=nlags, method=method, **kwargs)
     return _significant_acf(corr, kwargs.get('alpha'))
 

--- a/orangecontrib/timeseries/widgets/highcharts/highcharts.py
+++ b/orangecontrib/timeseries/widgets/highcharts/highcharts.py
@@ -12,17 +12,7 @@ import numpy as np
 from AnyQt.QtCore import QObject, pyqtSlot
 from AnyQt.QtWidgets import QApplication
 
-try:
-    from __opyhighcharts_interfaces import WebviewWidget
-except ImportError:
-    try:
-        from Orange.widgets.utils.webview import WebviewWidget
-    except ImportError:
-        # If required interfaces not available, provide some mocks
-        raise ImportError('opyhighcharts requires interface '
-                          'Orange.widgets.utils.webview.WebviewWidget'
-                          'positioned at '
-                          '__opyhighcharts_interfaces.WebviewWidget')
+from Orange.widgets.utils.webview import WebviewWidget
 
 
 def _Autotree():
@@ -156,7 +146,7 @@ class Highchart(WebviewWidget):
                                attrs)
                 bridge = _Bridge()
 
-        super().__init__(parent, bridge, debug=debug)
+        super().__init__(parent, bridge, js_timeout=10000, debug=debug)
 
         self.highchart = highchart
         self.enable_zoom = enable_zoom


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Let's see if this fixed the constant Timeout in Spiralogram. 🙄 
Partial autocorrelation test fails.

##### Description of changes
Widget inherits strictly from Orange's WebView and timeout increased.
Set minimum lags in partial_autocorrelation as specified in statstools.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
