### PR TITLE
Fix Seasonal Adjustment test

### DIFF
--- a/orangecontrib/timeseries/widgets/owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/owseasonaladjustment.py
@@ -92,6 +92,7 @@ class OWSeasonalAdjustment(widget.OWWidget):
             self.model.wrap([var for var in data.domain.variables
                              if var.is_continuous and var is not data.time_variable])
             self.controls.n_periods.setMaximum(min(MAX_PERIODS, len(data) - 1))
+            self.n_periods = self.controls.n_periods.value()
         else:
             self.Error.not_enough_instances()
         self.on_changed()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Seasonal Adjustment test was calling the spinbox incorrectly.

##### Description of changes
Call actual spinbox values.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
