### PR TITLE
Check time_variable in Timeseries.domain

### DIFF
--- a/orangecontrib/timeseries/tests/test_timeseries.py
+++ b/orangecontrib/timeseries/tests/test_timeseries.py
@@ -24,6 +24,16 @@ class TestTimeseries(unittest.TestCase):
         self.assertEqual(time_series.time_variable.name, 'date of birth')
         self.assertTrue(time_series.time_variable in time_series.domain.metas)
 
+    def test_time_var_removed(self):
+        ts_with_tv = Timeseries.from_file('airpassengers')
+        # select columns without time variable
+        ts_without_tv = Timeseries.from_data_table(ts_with_tv[:,
+                                      ts_with_tv.domain.class_var])
+        self.assertTrue(ts_with_tv.time_variable)
+        # make sure the Timeseries without time variable in domain has
+        # time_variable set to None
+        self.assertIsNone(ts_without_tv.time_variable)
+
 
 class TestTimestamp(unittest.TestCase):
     def test_timestamp(self):

--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -106,6 +106,10 @@ class Timeseries(Table):
                 and table.time_delta is not None:
             return table
 
+        if isinstance(table, Timeseries) \
+                and table.time_variable not in table.domain:
+            table.time_variable = None
+
         if time_attr is not None:
             if time_attr not in table.domain:
                 raise Exception(time_attr.name + ' is not in the domain.')


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It could happen that time_variable was set, but was removed from the domain.

##### Description of changes
Check that time_variable is in domain when constructing Timeseries.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
