### PR TITLE
OWSpiralogram: Fix broken Context in tests

### DIFF
--- a/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
@@ -79,7 +79,9 @@ class TestOWSpiralogram(WidgetTest):
         settings = {
             '__version__': 1,
             'context_settings': [
-                Context(values={'agg_attr': ([('Type', 101)], -3),
+                Context(attributes={'Type': 1, "foo": 2},
+                        metas={'name': 4},
+                        values={'agg_attr': ([('Type', 101)], -3),
                                 'agg_func': (0, -2),
                                 'ax1': ('months', -2),
                                 'ax2': ('years', -2)})],

--- a/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
@@ -98,10 +98,14 @@ class TestOWSpiralogram(WidgetTest):
         settings = {
             '__version__': 1,
             'context_settings': [
-                Context(values={'agg_attr': ([('Datetime', 104)], -3),
-                                'agg_func': (12, -2),
-                                'ax1': ('months', -2),
-                                'ax2': ('years', -2)})],
+                Context(
+                    attributes={'Datetime': 1, "foo": 2},
+                    metas={'name': 4},
+                    values={'agg_attr': ([('Datetime', 104)], -3),
+                            'agg_func': (12, -2),
+                            'ax1': ('months', -2),
+                            'ax2': ('years', -2)})
+            ],
             'controlAreaVisible': True,
             'invert_date_order': False,
             'savedWidgetGeometry': None


### PR DESCRIPTION
##### Issue

Test failed because of invalid `Context` instance.

##### Description of changes

Add attributes `attributes` and `metas` to `Context`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation