### PR TITLE
[FIX] Fix js_timout error in case of WebKit

### DIFF
--- a/orangecontrib/timeseries/widgets/highcharts/highcharts.py
+++ b/orangecontrib/timeseries/widgets/highcharts/highcharts.py
@@ -146,7 +146,9 @@ class Highchart(WebviewWidget):
                                attrs)
                 bridge = _Bridge()
 
-        super().__init__(parent, bridge, js_timeout=10000, debug=debug)
+        super().__init__(parent, bridge, debug=debug)
+        if hasattr(self, "js_timeout"):
+            self.js_timeout = 10000
 
         self.highchart = highchart
         self.enable_zoom = enable_zoom


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`WebView` based on `WebKitView` does not support `js_timeout` and fails on init. 

##### Description of changes
This workaround sets the `js_timout` only for `WebEngineView` based `WebView`. 
This is a temporary fix for https://github.com/biolab/orange-widget-base/pull/132

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
