### PR TITLE
OWAggregate: Change settings handler to PerfectDomainContextHandler

### DIFF
--- a/orangecontrib/timeseries/widgets/owaggregate.py
+++ b/orangecontrib/timeseries/widgets/owaggregate.py
@@ -8,7 +8,7 @@ from AnyQt.QtCore import Qt
 
 from Orange.data import Table, Domain, TimeVariable
 from Orange.widgets import widget, gui, settings
-from Orange.widgets.settings import ContextSetting, DomainContextHandler
+from Orange.widgets.settings import ContextSetting, PerfectDomainContextHandler
 from Orange.widgets.utils.itemmodels import PyTableModel
 from Orange.widgets.widget import Input, Output
 
@@ -30,7 +30,7 @@ class OWAggregate(widget.OWWidget):
     class Outputs:
         time_series = Output("Time series", Timeseries)
 
-    settingsHandler = DomainContextHandler()
+    settingsHandler = PerfectDomainContextHandler()
     variables = ContextSetting([])
     agg_funcs = ContextSetting([])
 

--- a/orangecontrib/timeseries/widgets/tests/test_owaggregate.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owaggregate.py
@@ -64,6 +64,23 @@ class TestOWAggregate(WidgetTest):
         self.send_signal(self.widget.Inputs.time_series, self.time_series)
         self.assertEqual(self.widget.model[0][1], AGG_FUNCTIONS[1])
 
+    def test_feature_change(self):
+        data = Table.from_url(
+            "https://datasets.biolab.si/core/philadelphia-crime.csv.xz")
+        domain1 = data.domain.select_columns({"Datetime", "Lon"})
+        data1 = data.transform(domain1)
+        domain2 = data.domain.select_columns({"Datetime"})
+        data2 = data.transform(domain2)
+        domain3 = data.domain.select_columns({"Datetime", "Type", "Lat"})
+        data3 = data.transform(domain3)
+
+        self.send_signal(self.widget.Inputs.time_series, data1)
+        self.assertEqual(len(self.widget.model), 1)
+        self.send_signal(self.widget.Inputs.time_series, data2)
+        self.assertEqual(len(self.widget.model), 0)
+        self.send_signal(self.widget.Inputs.time_series, data3)
+        self.assertEqual(len(self.widget.model), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Aggregate is empty if:
- connect entire data
- remove all features
- add back a subset of features

##### Description of changes
Change DomainContextHandler to PerfectDomainContextHandler.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
