### PR TITLE
Change documentation theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -144,7 +144,9 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['static']
+
+html_css_files = ['custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/static/custom.css
+++ b/doc/static/custom.css
@@ -1,0 +1,13 @@
+/* This CSS snippet makes that the navbar collapse on medium screen already */
+@media screen and (max-width: 950px){
+    .wy-nav-top{display:block}
+    .wy-nav-side{left:-300px}
+    .wy-nav-side.shift{width:85%;left:0}
+    .wy-side-scroll{width:auto}
+    .wy-side-nav-search{width:auto}
+    .wy-menu.wy-menu-vertical{width:auto}
+    .wy-nav-content-wrap{margin-left:0}
+    .wy-nav-content-wrap
+    .wy-nav-content{padding:1.618em}
+    .wy-nav-content-wrap.shift{position:fixed;min-width:100%;left:85%;top:0;height:100%;overflow:hidden}
+}

--- a/orangecontrib/timeseries/widgets/__init__.py
+++ b/orangecontrib/timeseries/widgets/__init__.py
@@ -11,9 +11,9 @@ BACKGROUND = "#33aaff"
 WIDGET_HELP_PATH = (
     # Used for development.
     # You still need to build help pages using
-    # make htmlhelp
+    # make html
     # inside doc folder
-    ("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+    ("{DEVELOP_ROOT}/doc/_build/html/index.html", None),
 
     # Online documentation url, used when the local documentation is available.
     # Url should point to a page with a section Widgets. This section should

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ if __name__ == '__main__':
             'python-dateutil'
         ],
         extras_require={
-            'test': ['coverage']
+            'test': ['coverage'],
+            'doc': ['sphinx', 'recommonmark', 'sphinx_rtd_theme'],
         },
         entry_points=ENTRY_POINTS,
         test_suite='orangecontrib.timeseries.tests.suite',


### PR DESCRIPTION
While ago we discussed that we will use the same documentation theme for add-ons. After some discussion, we decided on sphinx-rtd-theme. The alternative is Alabaster but its sidebar is not so readable and it breaks long addon names in two lines.

With this PR I am implementing the sphinx-rtd-theme. I also changed that the menu bar collapses on the medium screen already (before it collapsed on small screens). On the medium screen, the content column was narrow already and it works well for widget documentation in Orange since at the default Orange help window size the sidebar is collapsed.

