### PR TITLE
Line Chart: replace deprecated utcoffset

### DIFF
--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from numbers import Number
 from collections import OrderedDict
 from os.path import join, dirname
@@ -25,7 +26,7 @@ from Orange.widgets.settings import (
 )
 from Orange.widgets.utils.itemmodels import VariableListModel
 
-from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries import Timeseries, fromtimestamp
 from orangecontrib.timeseries.widgets.highcharts import Highchart
 
 
@@ -518,7 +519,7 @@ class OWLineChart(OWWidget):
             self.resize(QSize(925, 635))
 
     @Inputs.time_series
-    def set_data(self, data):
+    def set_data(self, data: Table):
         # TODO: set xAxis resolution and tooltip time contents depending on
         # data.time_delta. See: http://imgur.com/yrnlgQz
 
@@ -539,13 +540,23 @@ class OWLineChart(OWWidget):
             self.chart.clear()
             return
 
-        if getattr(data.time_variable, 'utc_offset', False):
-            offset_minutes = data.time_variable.utc_offset.total_seconds() / 60
-            self.chart.evalJS(
-                'Highcharts.setOptions({global: {timezoneOffset: %d}});'
-                % -offset_minutes
-            )  # Why is this negative? It works.
-            self.chart.chart()
+        if getattr(data.time_variable, "timezone", False):
+            # get all datetime values in as timestamp
+            t_values = data.get_column_view(data.time_variable)[0]
+            # get all offsets (it is possible to have multiple offsets because
+            # of changes in history and changes to dst)
+            offsets = set(
+                fromtimestamp(s, tz=data.time_variable.timezone).utcoffset()
+                for s in t_values
+            ) - {None}
+            # set offset only when same offset for all datetimes
+            if len(offsets) == 1:
+                offset_minutes = offsets.pop().total_seconds() / 60
+                self.chart.evalJS(
+                    "Highcharts.setOptions({global: {timezoneOffset: %d}});"
+                    % -offset_minutes
+                )  # Why is this negative? It works.
+                self.chart.chart()
 
         self.chart.setXAxisType(
             'datetime'

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from numbers import Number
 from collections import OrderedDict
 from os.path import join, dirname
@@ -554,9 +553,8 @@ class OWLineChart(OWWidget):
                 offset_minutes = offsets.pop().total_seconds() / 60
                 self.chart.evalJS(
                     "Highcharts.setOptions({global: {timezoneOffset: %d}});"
-                    % -offset_minutes
+                    % -60
                 )  # Why is this negative? It works.
-                self.chart.chart()
 
         self.chart.setXAxisType(
             'datetime'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
utcoffset on timevariable is deprecated. 


##### Description of changes
We replace it with timezone attribute and some logic for conversion

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
