### PR TITLE
[ENH] Use non-deprecated ARIMA implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         python-version: [3.7, 3.8]
         tox_env: [py-orange-released]
         experimental: [false]
@@ -34,7 +34,7 @@ jobs:
             experimental: true
             name: Big Sur
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.7
             tox_env: py-orange-oldest
             experimental: false
@@ -50,7 +50,7 @@ jobs:
             name: Oldest
             experimental: false
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.8
             tox_env: py-orange-latest
             experimental: false

--- a/orangecontrib/timeseries/tests/test_models.py
+++ b/orangecontrib/timeseries/tests/test_models.py
@@ -12,6 +12,20 @@ class TestARIMA(unittest.TestCase):
         model = ARIMA((2, 1, 0))
         model.fit(data)
         forecast, ci95_low, ci95_high = model.predict(10)
+
+        # results with deprecated ARIMA implementation
+        # fo = [466.409, 471.787, 467.914, 467.253, 469.951, 473.178, 475.83, 478.14, 480.454, 482.848]
+        # cl = [405.26, 367.617, 337.193, 318.22, 305.292, 293.814, 282.585, 271.934, 262.109, 253.028]
+        # ch = [527.558, 575.957, 598.636, 616.287, 634.609, 652.543, 669.074, 684.346, 698.798, 712.669]
+
+        fo = [464.2, 466.913, 460.612, 457.589, 457.872, 458.669, 458.908, 458.818, 458.729, 458.716]
+        cl = [402.92, 362.405, 329.234, 307.603, 292.039, 277.967, 264.189, 251.006, 238.651, 227.043]
+        ch = [525.48, 571.422, 591.989, 607.576, 623.706, 639.37, 653.627, 666.63, 678.807, 690.389]
+
+        np.testing.assert_almost_equal(forecast, fo, 3)
+        np.testing.assert_almost_equal(ci95_low, cl, 3)
+        np.testing.assert_almost_equal(ci95_high, ch, 3)
+
         self.assertTrue(
             np.logical_and(forecast > ci95_low, forecast < ci95_high).all())
 
@@ -20,6 +34,8 @@ class TestARIMA(unittest.TestCase):
         model.fit(data)
         forecast = model.predict(10, as_table=True)
         self.assertEqual(len(forecast.domain.variables), 1 + 2)
+        pred, ci95_low, ci95_high = model.predict(10)
+        np.testing.assert_equal(forecast, np.c_[pred, ci95_low, ci95_high])
 
 
 class TestVAR(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         },
         install_requires=[
             'Orange3',
-            'statsmodels>=0.10.0,<0.13.0',
+            'statsmodels>=0.13.0',
             'pandas',  # statsmodels requires this but doesn't have it in dependencies?
             'pandas_datareader',
             'numpy',

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ deps =
     oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
     oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
     oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
-    latest: git+git://github.com/biolab/orange3.git#egg=orange3
-    latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
-    latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
+    latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
 commands_pre =
     # Verify installed packages have compatible dependencies
     pip check


### PR DESCRIPTION
##### Issue
#177


##### Description of changes
I tried doing minimal changes to use a non-deprecated implementation. Works, but there is a problem: the results I obtain are different. See the test... Is this expected?

If we can not solve this is quickly I suggest pinning statsmodels <= 0.13 and making a release. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
