### PR TITLE
Updates for newer dependencies

### DIFF
--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -184,7 +184,7 @@ def _significant_acf(corr, has_confint):
     return result
 
 
-def autocorrelation(x, *args, unbiased=True, nlags=None, fft=True, **kwargs):
+def autocorrelation(x, *args, nlags=None, fft=True, **kwargs):
     """
     Return autocorrelation function of signal `x`.
 
@@ -209,7 +209,7 @@ def autocorrelation(x, *args, unbiased=True, nlags=None, fft=True, **kwargs):
     from statsmodels.tsa.stattools import acf
     if nlags is None:
         nlags = int(.9 * len(x))
-    corr = acf(x, *args, unbiased=unbiased, nlags=nlags, fft=fft, **kwargs)
+    corr = acf(x, *args, nlags=nlags, fft=fft, **kwargs)
     return _significant_acf(corr, kwargs.get('alpha'))
 
 

--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -395,7 +395,7 @@ def seasonal_decompose(data, model='multiplicative', period=12, *, callback=None
     for var in data.domain.variables:
         decomposed = sm.tsa.seasonal_decompose(np.ravel(interp_data[:, var]),
                                                model=model,
-                                               freq=period)
+                                               period=period)
         adjusted = recomposition(decomposed.observed,
                                  decomposed.seasonal)
 

--- a/orangecontrib/timeseries/functions.py
+++ b/orangecontrib/timeseries/functions.py
@@ -635,7 +635,7 @@ def model_evaluation(data, models, n_folds, forecast_steps, *, callback=None):
             if fittedvalues.ndim > 1:
                 fittedvalues = fittedvalues[..., 0]
         except Exception:
-            row = ['err'] * 7
+            row = ['err'] * 8
         else:
             row = _score_vector(model, true_y, fittedvalues)
         row[0] = row[0] + ' (in-sample)'

--- a/orangecontrib/timeseries/tests/test_interpolation.py
+++ b/orangecontrib/timeseries/tests/test_interpolation.py
@@ -7,10 +7,11 @@ from orangecontrib.timeseries import Timeseries, interpolate_timeseries
 class TestInterpolation(unittest.TestCase):
     def setUp(self):
         data = Timeseries.from_file('airpassengers')
-        data.Y[:2] = np.nan
-        data.Y[10:15] = np.nan
-        data.Y[-2:] = np.nan
-        self.data = data
+        with data.unlocked():
+            data.Y[:2] = np.nan
+            data.Y[10:15] = np.nan
+            data.Y[-2:] = np.nan
+            self.data = data
 
     def test_methods(self):
         for method in ('linear', 'cubic', 'nearest', 'mean'):

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -11,6 +11,7 @@ from Orange.widgets.widget import Input
 
 from orangecontrib.timeseries import Timeseries, model_evaluation
 from orangecontrib.timeseries.models import _BaseModel
+from orangewidget.utils.widgetpreview import WidgetPreview
 
 
 class Output:
@@ -44,8 +45,7 @@ class OWModelEvaluation(widget.OWWidget):
         unexpected_error = widget.Msg('Unexpected error: {}')
 
     class Warning(widget.OWWidget.Warning):
-        model_not_appropriate = widget.Msg(
-            'Model or its settings are not appropriate for this type of data.')
+        model_failed = widget.Msg('One or more models failed.')
 
     def __init__(self):
         self.data = None
@@ -89,7 +89,7 @@ class OWModelEvaluation(widget.OWWidget):
 
     def commit(self):
         self.Error.unexpected_error.clear()
-        self.Warning.model_not_appropriate.clear()
+        self.Warning.model_failed.clear()
         self.model.clear()
         data = self.data
         if not data or not self._models:

--- a/orangecontrib/timeseries/widgets/owmodelevaluation.py
+++ b/orangecontrib/timeseries/widgets/owmodelevaluation.py
@@ -103,39 +103,21 @@ class OWModelEvaluation(widget.OWWidget):
             self.Error.unexpected_error(e.args[0])
             return
         res = np.array(res, dtype=object)
-        if res.ndim > 1:
-            self.model.setHorizontalHeaderLabels(res[0, 1:].tolist())
-            self.model.setVerticalHeaderLabels(res[1:, 0].tolist())
-            self.model.wrap(res[1:, 1:].tolist())
-        else:
-            self.Warning.model_not_appropriate()
+        self.Warning.model_failed(shown="err" in res)
+        self.model.setHorizontalHeaderLabels(res[0, 1:].tolist())
+        self.model.setVerticalHeaderLabels(res[1:, 0].tolist())
+        self.model.wrap(res[1:, 1:].tolist())
 
 
 if __name__ == "__main__":
-    from AnyQt.QtWidgets import QApplication
-    from Orange.data import Domain
+    class BadModel(_BaseModel):
+        def _predict(self):
+            return 1 / 0
+
     from orangecontrib.timeseries import ARIMA, VAR
-
-    a = QApplication([])
-    ow = OWModelEvaluation()
-
     data = Timeseries.from_file('airpassengers')
-    # Make Adjusted Close a class variable
-    attrs = [var.name for var in data.domain.attributes]
-    if 'Adj Close' in attrs:
-        attrs.remove('Adj Close')
-        data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']], None,
-                                            source=data.domain),
-                                     data)
-
-    ow.set_data(data)
-    ow.set_model(ARIMA((1, 1, 1)), 1)
-    ow.set_model(ARIMA((2, 1, 0)), 2)
-    # ow.set_model(ARIMA((0, 1, 1)), 3)
-    # ow.set_model(ARIMA((4, 1, 0)), 4)
-    ow.set_model(VAR(1), 11)
-    ow.set_model(VAR(5), 12)
-    # ow.set_model(VAR(6), 14)
-
-    ow.show()
-    a.exec()
+    learners = [ARIMA((1, 1, 1)), ARIMA((2, 1, 0)), VAR(1), VAR(5), BadModel()]
+    WidgetPreview(OWModelEvaluation).run(
+        set_data=data,
+        set_model=[(model, i) for i, model in enumerate(learners)]
+    )

--- a/orangecontrib/timeseries/widgets/tests/test_owaggregate.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owaggregate.py
@@ -27,7 +27,8 @@ class TestOWAggregate(WidgetTest):
             metas=[DiscreteVariable("meta", values=["0"])]
         )
         data = self.time_series.transform(new_domain)
-        data.metas = np.zeros((144, 1), dtype=object)
+        with data.unlocked(data.metas):
+            data.metas = np.zeros((144, 1), dtype=object)
         self.assertEqual(len(data.metas.shape), 2)
         self.send_signal(w.Inputs.time_series, data)
         w.controls.autocommit.click()

--- a/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owcorrelogram.py
@@ -24,9 +24,11 @@ class TestCorrelogramWidget(WidgetTest):
             Domain(attributes=[ContinuousVariable("a"), ContinuousVariable("b")]),
             list(zip(list(range(5)), list(range(5))))
         )
-        time_series.X[:, 1] = np.nan
+        with time_series.unlocked():
+            time_series.X[:, 1] = np.nan
         self.send_signal(self.widget.Inputs.time_series, time_series)
-        time_series.X[2, 1] = 42
+        with time_series.unlocked():
+            time_series.X[2, 1] = 42
         self.send_signal(self.widget.Inputs.time_series, time_series)
 
     def test_no_instances(self):

--- a/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owseasonaladjustment.py
@@ -19,7 +19,8 @@ class TestOWSeasonalAdjustment(WidgetTest):
         """
         w = self.widget
         table = Timeseries.from_file("iris")
-        table.X[1, 1] = -1
+        with table.unlocked():
+            table.X[1, 1] = -1
         w.decomposition = 1
         w.autocommit = True
         self.assertFalse(w.Error.seasonal_decompose_fail.is_shown())

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -33,12 +33,13 @@ class TestAsTimeSeriesWidget(WidgetTest):
         GH-30
         """
         w = self.widget
-        data = Table("iris")[:2]
+        data = Table("iris")[:2].copy()
         self.assertFalse(w.Information.nan_times.is_shown())
         self.send_signal(w.Inputs.data, data)
         self.assertFalse(w.Information.nan_times.is_shown())
         self.assertIsInstance(self.get_output(w.Outputs.time_series), Timeseries)
-        data.X[:, 0] = np.nan
+        with data.unlocked():
+            data.X[:, 0] = np.nan
         self.send_signal(w.Inputs.data, data)
         self.assertTrue(w.Information.nan_times.is_shown())
         self.assertIsNone(self.get_output(w.Outputs.time_series))

--- a/tox.ini
+++ b/tox.ini
@@ -24,15 +24,7 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc
 deps =
-    pyqt5==5.12.*
-    pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.25.0
-    # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.9 ; sys_platform != 'win32'
-    oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
-    oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
-    oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
+    oldest: orange3==3.31.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,13 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc
 deps =
+    oldest: pyqt5==5.12.*
+    oldest: pyqtwebengine==5.12.*
     oldest: orange3==3.31.0
+    # orange3==3.31.0 requires the following
+    oldest: orange-widget-base==4.16.1
+    oldest: orange-canvas-core==0.1.24
+    oldest: statsmodels==0.13.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

There have been multiple changes in statsmodels, as well as in Orange, for instance table locking.

Also fixes #196.

##### Description of changes

- I unlocked tables where necessary: `TimeSeries` was unlockable because it was constructed as a view into an intermediate table
- I increase required Orange version to 3.31 and removed pins (otherwise installation failed due to conflicts)
- argument 'unbiased' in call of `autocorrelation` was removed because it is no longer available; there have been some arguments against "unbiasing" models in this way.
- `freq` has been renamed to `period`; meaning is the same, I've found the `statsmodels`'s commit in which they renamed it
- Model Evaluation contained an invalid fix (#37): if a classifier errored, some function returned a list with 6 "err" strings instead of 7; numpy couldn't create a proper 2d array and created a 1d array of lists. This was "fixed" so that a widget checked `ndim` and if it was `1`, printed a warning "something went wrong". 🤯
    I added a missing "err" (which was, as I see, all that would need to be done in #37!, but then still kept a rephrased warning about errored model(s).
 
##### Includes
- [X] Code changes
- [X] Tests
