### PR TITLE
Revert "ARIMA, Var: Minor refactoring and GUI update"

### DIFF
--- a/orangecontrib/timeseries/widgets/owarimamodel.py
+++ b/orangecontrib/timeseries/widgets/owarimamodel.py
@@ -1,10 +1,4 @@
-from AnyQt.QtCore import Qt
-from AnyQt.QtWidgets import QFormLayout
-
-from orangewidget.utils.widgetpreview import WidgetPreview
-
-from Orange.data import Domain
-from Orange.widgets import gui, settings
+from Orange.widgets import widget, gui, settings
 from Orange.widgets.widget import Input
 
 from orangecontrib.timeseries import Timeseries, ARIMA
@@ -22,6 +16,15 @@ class OWARIMAModel(OWBaseModel):
     q = settings.Setting(0)
     use_exog = settings.Setting(False)
 
+    UserAdviceMessages = [
+        widget.Message('ARIMA(0,1,0) equals to a random walk model, which '
+                       'is an AR(1) model with the auto-regression coefficient '
+                       'equal to 1, and the constant term (i.e. the period-to-period '
+                       "change) equal to the series' long-term drift.",
+                       'random-walk',
+                       widget.Message.Warning)
+    ]
+
     class Inputs(OWBaseModel.Inputs):
         exogenous_data = Input("Exogenous data", Timeseries)
 
@@ -35,16 +38,16 @@ class OWARIMAModel(OWBaseModel):
         self.update_model()
 
     def add_main_layout(self):
-        layout = QFormLayout()
-        self.controlArea.layout().addLayout(layout)
-        kwargs = dict(controlWidth=50, alignment=Qt.AlignRight,
-                      callback=self.apply.deferred)
-        layout.addRow('Auto-regression order (p):',
-                      gui.spin(None, self, 'p', 0, 100, **kwargs))
-        layout.addRow('Differencing degree (d):',
-                      gui.spin(None, self, 'd', 0, 2, **kwargs))
-        layout.addRow('Moving average order (q):',
-                      gui.spin(None, self, 'q', 0, 100, **kwargs))
+        box = gui.vBox(self.controlArea, box='Parameters')
+        gui.spin(box, self, 'p', 0, 100, label='Auto-regression order (p):',
+                 callback=self.apply)
+        gui.spin(box, self, 'd', 0, 2, label='Differencing degree (d):',
+                 callback=self.apply)
+        gui.spin(box, self, 'q', 0, 100, label='Moving average order (q):',
+                 callback=self.apply)
+        gui.checkBox(box, self, 'use_exog',
+                     'Use exogenous (independent) variables (ARMAX)',
+                     callback=self.apply)
 
     def forecast(self, model):
         if self.use_exog and self.exog_data is None:
@@ -59,7 +62,16 @@ class OWARIMAModel(OWBaseModel):
 
 
 if __name__ == "__main__":
+    from AnyQt.QtWidgets import QApplication
+    from Orange.data import Domain
+
+    a = QApplication([])
+    ow = OWARIMAModel()
+
     data = Timeseries.from_file('airpassengers')
     domain = Domain(data.domain.attributes[:-1], data.domain.attributes[-1])
     data = Timeseries.from_numpy(domain, data.X[:, :-1], data.X[:, -1])
-    WidgetPreview(OWARIMAModel).run(set_data=data)
+    ow.set_data(data)
+
+    ow.show()
+    a.exec()

--- a/orangecontrib/timeseries/widgets/owvarmodel.py
+++ b/orangecontrib/timeseries/widgets/owvarmodel.py
@@ -1,7 +1,6 @@
-from AnyQt.QtCore import Qt
+from collections import OrderedDict
 
-from orangewidget.utils.widgetpreview import WidgetPreview
-from Orange.widgets import gui, settings
+from Orange.widgets import widget, gui, settings
 from orangecontrib.timeseries import Timeseries, VAR
 from orangecontrib.timeseries.widgets._owmodel import OWBaseModel
 
@@ -16,36 +15,37 @@ class OWVARModel(OWBaseModel):
     ic = settings.Setting(0)
     trend = settings.Setting(0)
 
-    IC_LABELS = dict((('None', None),
-                      ("Akaike's information criterion (AIC)", 'aic'),
-                      ('Bayesian information criterion (BIC)', 'bic'),
-                      ('Hannan–Quinn', 'hqic'),
-                      ("Final prediction error (FPE)", 'fpe'),
-                      ('Average of the above', 'magic')))
-    TREND_LABELS = dict((('None', 'n'),
-                         ('Constant', 'c'),
-                         ('Constant and linear', 'ct'),
-                         ('Constant, linear and quadratic', 'ctt')))
+    UserAdviceMessages = [
+        widget.Message('Note, VAR model requires the series to be stationary.',
+                       'stationary',
+                       widget.Message.Warning)
+    ]
+
+    IC_LABELS = OrderedDict((('None', None),
+                             ("Akaike's information criterion (AIC)", 'aic'),
+                             ('Bayesian information criterion (BIC)', 'bic'),
+                             ('Hannan–Quinn', 'hqic'),
+                             ("Final prediction error (FPE)", 'fpe'),
+                             ('Average of the above', 'magic')))
+    TREND_LABELS = OrderedDict((('None', 'nc'),
+                                ('Constant', 'c'),
+                                ('Constant and linear', 'ct'),
+                                ('Constant, linear and quadratic', 'ctt')))
 
     def add_main_layout(self):
         box = gui.vBox(self.controlArea, box='Parameters')
-        gui.spin(
-            box, self, 'maxlags', 1, 100,
-            label='Maximum auto-regression order:', alignment=Qt.AlignRight,
-            callback=self.apply.deferred)
-        gui.separator(self.controlArea, 12)
-        box = gui.vBox(self.controlArea, box=True)
+        gui.spin(box, self, 'maxlags', 1, 100, label='Maximum auto-regression order:',
+                 callback=self.apply)
         gui.radioButtons(
             box, self, 'ic',
-            btnLabels=tuple(self.IC_LABELS),
-            label='Optimize AR order by:',
-            callback=self.apply.deferred)
-        gui.separator(self.controlArea, 12)
+            btnLabels=tuple(self.IC_LABELS.keys()),
+            box='Information criterion', label='Optimize AR order by:',
+            callback=self.apply)
         gui.radioButtons(
             box, self, 'trend',
-            btnLabels=tuple(self.TREND_LABELS),
-            label='Add trend vector(s):',
-            callback=self.apply.deferred)
+            btnLabels=tuple(self.TREND_LABELS.keys()),
+            box='Trend', label='Add trend vector(s):',
+            callback=self.apply)
 
     def create_learner(self):
         ic = self.IC_LABELS[tuple(self.IC_LABELS.keys())[self.ic]]
@@ -54,5 +54,13 @@ class OWVARModel(OWBaseModel):
 
 
 if __name__ == "__main__":
+    from AnyQt.QtWidgets import QApplication
+
+    a = QApplication([])
+    ow = OWVARModel()
+
     data = Timeseries.from_file('airpassengers')
-    WidgetPreview(OWVARModel).run(set_data=data)
+    ow.set_data(data)
+
+    ow.show()
+    a.exec()


### PR DESCRIPTION
Reverts biolab/orange3-timeseries#200. Fixes #206.

We overlooked the comment that #200 requires https://github.com/biolab/orange-widget-base/pull/202, which means it will have to wait for the next version of Orange. We could revert #200 partially, but there is nothing really essential there, so we can revert whole of it.