### PR TITLE
As Timeseries: Fix crash on sparse data

### DIFF
--- a/orangecontrib/timeseries/timeseries.py
+++ b/orangecontrib/timeseries/timeseries.py
@@ -199,10 +199,10 @@ class Timeseries(Table):
         return super(Timeseries, cls).from_table(table.domain, table)
 
     @classmethod
-    def make_timeseries_from_continuous_var(cls, table, attr_name):
+    def make_timeseries_from_continuous_var(cls, table, attr):
         # Make a sequence attribute from one of the existing attributes,
         # and sort all values according to it
-        time_var = table.domain[attr_name]
+        time_var = table.domain[attr]
         values = table.get_column_view(time_var)[0].astype(float)
         # Filter out NaNs
         nans = np.isnan(values)

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -87,14 +87,14 @@ class OWTableToTimeseries(widget.OWWidget):
         if self.radio_sequential:
             ts = Timeseries.make_timeseries_from_sequence(data)
         else:
-            ts = Timeseries.make_timeseries_from_continuous_var(data,
-                                                                self.selected_attr)
-            # Check if NaNs were present in data
-            time_var = data.domain[self.selected_attr]
-            values = Table.from_table(Domain([], [], [time_var]),
-                                      source=data).metas.ravel()
-            if np.isnan(values).any():
-                self.Information.nan_times(time_var.name)
+            ts = Timeseries.make_timeseries_from_continuous_var(
+                data, self.selected_attr)
+            # Warn if instances are omitted because of nans in selected attr
+            times, sparse = data.get_column_view(self.selected_attr)
+            if sparse:
+                times = times.data
+            if np.isnan(times).any():
+                self.Information.nan_times(self.selected_attr)
 
         self.Outputs.time_series.send(ts)
 

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -2,8 +2,12 @@ from itertools import chain
 
 import numpy as np
 
-from Orange.data import Table, ContinuousVariable, TimeVariable, Domain
+from AnyQt.QtWidgets import QGridLayout
+
+from orangewidget.utils.widgetpreview import WidgetPreview
+from Orange.data import Table
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.settings import DomainContextHandler
 from Orange.widgets.utils.itemmodels import VariableListModel
 from Orange.widgets.widget import Input, Output
 
@@ -12,7 +16,7 @@ from orangecontrib.timeseries import Timeseries
 
 class OWTableToTimeseries(widget.OWWidget):
     name = 'As Timeseries'
-    description = ('Reinterpret data table as a time series object.')
+    description = 'Reinterpret data table as a time series.'
     icon = 'icons/TableToTimeseries.svg'
     priority = 10
 
@@ -25,8 +29,13 @@ class OWTableToTimeseries(widget.OWWidget):
     want_main_area = False
     resizing_enabled = False
 
-    radio_sequential = settings.Setting(0)
+    # Old settings that can't be migrated, but can be supported
     selected_attr = settings.Setting('')
+    radio_sequential = settings.Setting(2)
+
+    settingsHandler = DomainContextHandler()
+    implied_sequence = settings.ContextSetting(0)
+    order = settings.ContextSetting(None)
     autocommit = settings.Setting(True)
 
     class Information(widget.OWWidget.Information):
@@ -35,78 +44,82 @@ class OWTableToTimeseries(widget.OWWidget):
 
     def __init__(self):
         self.data = None
-        box = gui.vBox(self.controlArea, 'Sequence')
-        group = gui.radioButtons(box, self, 'radio_sequential',
-                                 callback=self.on_changed)
-        hbox = gui.hBox(box)
-        gui.appendRadioButton(group, 'Sequential attribute:',
-                              insertInto=hbox)
 
-        attrs_model = self.attrs_model = VariableListModel()
-        combo_attrs = self.combo_attrs = gui.comboBox(
-            hbox, self, 'selected_attr',
-            callback=self.on_changed,
-            sendSelectedValue=True)
-        combo_attrs.setModel(attrs_model)
-
-        gui.appendRadioButton(group, 'Sequence is implied by instance order',
-                              insertInto=box)
+        layout = QGridLayout()
+        gui.widgetBox(self.controlArea, True, orientation=layout)
+        group = gui.radioButtons(
+            None, self, 'implied_sequence', callback=self.commit.deferred)
+        layout.addWidget(
+            gui.appendRadioButton(
+                group, 'Sequential attribute:', addToLayout=False),
+            0, 0)
+        layout.addWidget(
+            gui.comboBox(
+                None, self, 'order', model=VariableListModel(),
+                callback=self._on_attribute_changed),
+            0, 1)
+        layout.addWidget(
+            gui.appendRadioButton(
+                group, 'Sequence implied by instance order', addToLayout=False),
+            1, 0, 1, 2)
 
         gui.auto_commit(self.controlArea, self, 'autocommit', '&Apply')
         # TODO: seasonally adjust data (select attributes & season cycle length (e.g. 12 if you have monthly data))
 
+    def _on_attribute_changed(self):
+        self.implied_sequence = 0
+        self.commit.deferred()
+
     @Inputs.data
     def set_data(self, data):
+        self.closeContext()
         self.data = data
-        self.attrs_model.clear()
-        if self.data is None:
-            self.commit()
-            return
+        model = self.controls.order.model()
+        if data:
+            valid = (var
+                     for var in chain(data.domain.variables, data.domain.metas)
+                     if var.is_continuous)
+            model[:] = sorted(valid, key=lambda var: not var.is_time)
+        else:
+            model.clear()
 
-        if data.domain.has_continuous_attributes(include_metas=True):
-            vars = [var for var in data.domain.variables if var.is_time] + \
-                   [var for var in data.domain.metas if var.is_time] + \
-                   [var for var in data.domain.variables
-                    if var.is_continuous and not var.is_time] + \
-                   [var for var in data.domain.metas if var.is_continuous and
-                    not var.is_time]
-            self.attrs_model[:] = vars
-            self.selected_attr = data.time_variable.name if getattr(data, 'time_variable', False) else vars[0].name
-        self.on_changed()
+        if not model:
+            self.implied_sequence = 1
+        # radio_sequential and selected_attr can't be migrated, but can be used
+        elif self.radio_sequential != 2:
+            self.implied_sequence = self.radio_sequential
+        if model:
+            if self.selected_attr in data.domain \
+                    and data.domain[self.selected_attr] in model:
+                self.order = data.domain[self.selected_attr]
+            else:
+                self.order = getattr(data, "time_variable", model[0])
+        self.controls.implied_sequence.buttons[0].setDisabled(not model)
+        self.openContext(data)
+        self.commit.now()
 
-    def on_changed(self):
-        self.commit()
-
+    @gui.deferred
     def commit(self):
         data = self.data
         self.Information.clear()
-        if data is None or (self.selected_attr not in data.domain and not self.radio_sequential):
+        if not data:
             self.Outputs.time_series.send(None)
             return
 
-        if self.radio_sequential:
+        if self.order is None:
             ts = Timeseries.make_timeseries_from_sequence(data)
         else:
-            ts = Timeseries.make_timeseries_from_continuous_var(
-                data, self.selected_attr)
+            ts = Timeseries.make_timeseries_from_continuous_var(data, self.order)
             # Warn if instances are omitted because of nans in selected attr
-            times, sparse = data.get_column_view(self.selected_attr)
+            times, sparse = data.get_column_view(self.order)
             if sparse:
                 times = times.data
             if np.isnan(times).any():
-                self.Information.nan_times(self.selected_attr)
+                self.Information.nan_times(self.order.name)
 
         self.Outputs.time_series.send(ts)
 
 
 if __name__ == "__main__":
-    from AnyQt.QtWidgets import QApplication
-
-    a = QApplication([])
-    ow = OWTableToTimeseries()
-
     data = Timeseries.from_file('airpassengers')
-    ow.set_data(data)
-
-    ow.show()
-    a.exec()
+    WidgetPreview(OWTableToTimeseries).run(data)

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -21,11 +21,12 @@ class TestAsTimeSeriesWidget(WidgetTest):
         w = self.widget
         data = Table.from_url("http://file.biolab.si/datasets/cyber-security-breaches.tab")[:20]
         self.send_signal(w.Inputs.data, data)
-        self.assertEqual(len(w.attrs_model), 4)
+        model = w.controls.order.model()
+        self.assertEqual(len(model), 4)
         new_domain = Domain(data.domain[:6], metas=[data.domain[6]])
         new_data = Table.from_table(new_domain, data)
         self.send_signal(w.Inputs.data, new_data)
-        self.assertEqual(len(w.attrs_model), 4)
+        self.assertEqual(len(model), 4)
 
     def test_timeseries_column_nans(self):
         """
@@ -48,61 +49,47 @@ class TestAsTimeSeriesWidget(WidgetTest):
         widget = self.widget
         widget.radio_sequential = 0
 
+        x, y, m = (ContinuousVariable(n) for n in "xym")
         domain = Domain(
-            [DiscreteVariable("a", values=tuple("abc")),
-             ContinuousVariable("x"),
-             ContinuousVariable("y")],
+            [DiscreteVariable("a", values=tuple("abc")), x, y],
             DiscreteVariable("c"),
-            [ContinuousVariable("m")])
-        x = sp.csr_matrix([[0, 1, 0], [2, 0, np.nan], [0, -1, 2]])
-        y = sp.csr_matrix([[0], [1], [np.nan]])
-        m = sp.csr_matrix([[0], [3], [np.nan]])
-        data = Table.from_numpy(domain, x, y, m)
+            [m])
+        xs = sp.csr_matrix([[0, 1, 0], [2, 0, np.nan], [0, -1, 2]])
+        ys = sp.csr_matrix([[0], [1], [np.nan]])
+        ms = sp.csr_matrix([[0], [3], [np.nan]])
+        data = Table.from_numpy(domain, xs, ys, ms)
         self.send_signal(widget.Inputs.data, data)
 
-        widget.selected_attr = "x"
-        widget.commit()
+        widget.order = x
+        widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
             out.X, [[0, -1, 2], [2, 0, np.nan], [0, 1, 0]])
 
-        widget.selected_attr = "y"
-        widget.commit()
+        widget.order = y
+        widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
             out.X, [[0, 1, 0], [0, -1, 2]])
         self.assertTrue(widget.Information.nan_times.is_shown())
 
-        widget.selected_attr = "m"
-        widget.commit()
+        widget.order = m
+        widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
             out.X, [[0, 1, 0], [2, 0, np.nan]])
         self.assertTrue(widget.Information.nan_times.is_shown())
 
-        widget.selected_attr = "x"
-        widget.commit()
+        widget.order = x
+        widget.commit.now()
         self.assertFalse(widget.Information.nan_times.is_shown())
 
-        widget.selected_attr = "m"
-        widget.commit()
+        widget.order = m
+        widget.commit.now()
         self.assertTrue(widget.Information.nan_times.is_shown())
 
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Information.nan_times.is_shown())
-
-    def test_non_cont_sequental(self):
-        """
-        Widget can create sequental time variable and values
-        if input data does not have any continuous variables.
-        GH-40
-        """
-        w = self.widget
-        table = Table("titanic")
-        self.send_signal(w.Inputs.data, table)
-        self.assertIsNone(self.get_output(w.Outputs.time_series))
-        w.controls.radio_sequential.buttons[1].click()
-        self.assertIsNotNone(self.get_output(w.Outputs.time_series))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Fixes #106.

##### Description of changes

- Problem when the user selected an attribute was caused by a check whether the column contains any nans.

    I cannot replicate the bug when using a sequence. Maybe this was already fixed somewhere. @ajdapretnar, please check.

- The second commit updates the widget's code to use

    - context settings, with variables instead of strings
    - `QGridLayout`, for more accurate spacing
    - deferred commit
    - `WidgetPreview`

##### Includes
- [X] Code changes
- [X] Tests