### PR TITLE
[FIX] Line Chart: Fix tooltip for missing line data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9, '3.10']
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
@@ -35,33 +35,33 @@ jobs:
             name: Big Sur
 
           - os: windows-2019
-            python-version: 3.7
+            python-version: 3.8
             tox_env: py-orange-oldest
             experimental: false
             name: Oldest
           - os: macos-10.15
-            python-version: 3.7
+            python-version: 3.8
             tox_env: py-orange-oldest
             name: Oldest
             experimental: false
           - os: ubuntu-18.04
-            python-version: 3.7
+            python-version: 3.8
             tox_env: py-orange-oldest
             name: Oldest
             experimental: false
 
           - os: windows-2019
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: py-orange-latest
             experimental: false
             name: Latest
           - os: macos-10.15
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: py-orange-latest
             experimental: false
             name: Latest
           - os: ubuntu-18.04
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: py-orange-latest
             experimental: false
             name: Latest

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -433,16 +433,21 @@ class LineChartPlotItem(PlotItem):
 
         for item in self.items[:]:
             if isinstance(item, DotItem):
-                item.setData([x_pos], [item.source_data[x_pos]])
-                item.show()
+                if x_pos in item.source_data:
+                    item.setData([x_pos], [item.source_data[x_pos]])
+                    item.show()
+                else:
+                    item.hide()
 
     def get_tooltip_html(self, x_pos: int) -> str:
         if not self.__curves_data:
             return ""
 
-        index = list(self.__curves_data[0].x_total).index(x_pos)
         html = ""
         for curve_data in self.__curves_data:
+            if x_pos not in list(curve_data.x_total):
+                continue
+            index = list(curve_data.x_total).index(x_pos)
             y = curve_data.y_total[index]
             y = "?" if np.isnan(y) else y
             html += f'<div>' \

--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -272,7 +272,7 @@ class LineChartPlotItem(PlotItem):
             x_total[:len(y_true)], y_true, name=name,
             pen=pg.mkPen(color, width=width), **kwargs
         )
-        # item.curve.setSegmentedLineMode("on")
+        item.curve.setSegmentedLineMode("on")
         self.addItem(item)
 
         if y_pred is not None:
@@ -285,7 +285,7 @@ class LineChartPlotItem(PlotItem):
                 x, extend_last_val(y_pred),
                 pen=pg.mkPen(color, width=width, style=Qt.DashLine), **kwargs
             )
-            # pred.curve.setSegmentedLineMode("on")
+            pred.curve.setSegmentedLineMode("on")
             self.addItem(pred)
 
             if y_pred_low is not None and y_pred_high is not None:
@@ -294,14 +294,14 @@ class LineChartPlotItem(PlotItem):
                     pen=pg.mkPen(color, width=width, style=Qt.DotLine),
                     **kwargs
                 )
-                # low.curve.setSegmentedLineMode("on")
+                low.curve.setSegmentedLineMode("on")
                 self.addItem(low)
                 high = pg.PlotDataItem(
                     x, extend_last_val(y_pred_high),
                     pen=pg.mkPen(color, width=width, style=Qt.DotLine),
                     **kwargs
                 )
-                # high.curve.setSegmentedLineMode("on")
+                high.curve.setSegmentedLineMode("on")
                 self.addItem(high)
 
                 ci_color = QColor(color)
@@ -520,7 +520,7 @@ class LineChartGraph(pg.GraphicsLayoutWidget):
             specs = ax.generateDrawSpecs(painter)
             painter.end()
 
-            if specs is not None:
+            if specs is not None and len(specs[-1]) > 0:
                 width = max([spec[0].width() for spec in specs[-1]]) + 5
                 widths.append(width)
 

--- a/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
@@ -134,17 +134,6 @@ class TestOWLineChart(WidgetTest):
         self.send_signal(self.widget.Inputs.forecast, pred)
         self.widget._graph._show_tooltips(QPointF())
 
-    def test_pyqtgraph_setSegmentedLineMode(self):
-        """
-        When this starts to fail, uncomment the lines with
-        setSegmentedLineMode in owlinechart (274, 287, 296 and 303),
-        and remove this test.
-        """
-        import pyqtgraph as pg
-
-        curve = pg.PlotCurveItem()
-        self.assertFalse(hasattr(curve, "setSegmentedLineMode"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owlinechart.py
@@ -1,13 +1,17 @@
 import os
 import unittest
+from unittest.mock import patch, Mock
+
+from AnyQt.QtCore import QPointF
+import pyqtgraph as pg
 
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.widget import AttributeList
-from Orange.data import Table
-
+from Orange.data import Table, ContinuousVariable
 
 from orangecontrib.timeseries import Timeseries, ARIMA
-from orangecontrib.timeseries.widgets.owlinechart import OWLineChart
+from orangecontrib.timeseries.widgets.owlinechart import OWLineChart, \
+    LineChartEditor
 
 
 class TestOWLineChart(WidgetTest):
@@ -111,6 +115,24 @@ class TestOWLineChart(WidgetTest):
         self.assertEqual(1, len(self.widget._editors))
         self.assertEqual(1, len(self.widget.attrs))
         self.assertEqual(0, len(self.widget.attrs[0]))
+
+    @patch.object(pg.ViewBox, "mapSceneToView",
+                  Mock(return_value=QPointF(-263298814, 367)))
+    def test_tooltip(self):
+        table = Timeseries.from_file("airpassengers")
+        var = ContinuousVariable("var")
+        new_table = table.add_column(var, table.Y)
+        self.send_signal(self.widget.Inputs.time_series, new_table)
+
+        editor: LineChartEditor = self.widget._editors[0]
+        vars_ = [new_table.domain["var"], new_table.domain["Air passengers"]]
+        editor.set_parameters({"vars": vars_})
+        editor.sigEdited.emit(editor)
+
+        model = ARIMA((3, 1, 1)).fit(table)
+        pred = model.predict(20, as_table=True)
+        self.send_signal(self.widget.Inputs.forecast, pred)
+        self.widget._graph._show_tooltips(QPointF())
 
     def test_pyqtgraph_setSegmentedLineMode(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             # required to get current timezone
             # adding it does not hurt, Pandas have it as a dependency
             'python-dateutil',
-            'pyqtgraph>=0.12.2,!=0.12.4'
+            'pyqtgraph>=0.13.1',
         ],
         extras_require={
             'test': ['coverage'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}-orange-{oldest, latest, released}
+    py{38,39,310}-orange-{oldest, latest, released}
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ deps =
     # orange3==3.31.0 requires the following
     oldest: orange-widget-base==4.16.1
     oldest: orange-canvas-core==0.1.24
-    oldest: statsmodels==0.13.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Line Chart widget crashes when rolling the cursor over an area that some lines are missing the data (usually the forecast area).

To reproduce, create the following workflow and move the cursor to where the `Air passenger (mean)` is missing

![image](https://user-images.githubusercontent.com/11465003/194500991-81b2d8fa-80cd-4c85-9112-7b33e1992a08.png)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
