### PR TITLE
[ENH] As Timeseries: Assign time stamps when using implied order

### DIFF
--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -52,16 +52,16 @@ class IntOrEmptyValidator(QValidator):
             input, pos)
 
 class LineEdit(QLineEdit):
-    def __init__(self, *args, default, onFinish, onFocus, **kwargs):
+    def __init__(self, *args, default, onFinish, onClick, **kwargs):
         super().__init__(*args, **kwargs)
         self.setPlaceholderText(default)
-        self._onFocus = onFocus
+        self._onClick = onClick
         self.setValidator(IntOrEmptyValidator())
         self.editingFinished.connect(onFinish)
 
-    def focusInEvent(self, event):
-        super().focusInEvent(event)
-        self._onFocus()
+    def mousePressEvent(self, event):
+        super().mousePressEvent(event)
+        self._onClick()
 
     def text(self):
         return super().text().strip() or self.placeholderText()
@@ -145,11 +145,11 @@ class OWTableToTimeseries(widget.OWWidget):
         y, m, d = self.start_date
         numargs = dict(
             alignment=Qt.AlignCenter, maximumWidth=numwidth * 4,
-            onFinish=self._on_time_changed, onFocus=self._on_implied_focused)
+            onFinish=self._on_time_changed, onClick=self._on_implied_clicked)
         self.date_edits = (
             LineEdit(
                 str(y), default="2000",
-                onFinish=self._on_time_changed, onFocus=self._on_implied_focused,
+                onFinish=self._on_time_changed, onClick=self._on_implied_clicked,
                 alignment=Qt.AlignRight, maximumWidth=numwidth * 6),
             combo := QComboBox(),
             LineEdit(str(d), default="01", **numargs)
@@ -189,7 +189,7 @@ class OWTableToTimeseries(widget.OWWidget):
         box.layout().addWidget(
             LineEdit(
                 str(self.steps), default="1", objectName="stepline",
-                onFinish=self._on_steps_changed, onFocus=self._on_implied_focused,
+                onFinish=self._on_steps_changed, onClick=self._on_implied_clicked,
                 alignment=Qt.AlignRight, maximumWidth=4 * numwidth)
         )
         gui.comboBox(
@@ -219,7 +219,7 @@ class OWTableToTimeseries(widget.OWWidget):
         self.attribute = self.var_combo.currentText()
         self.commit.deferred()
 
-    def _on_implied_focused(self):
+    def _on_implied_clicked(self):
         if self.implied_sequence != 1:
             self.implied_sequence = 1
             self.commit.deferred()

--- a/orangecontrib/timeseries/widgets/owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/owtabletotimeseries.py
@@ -1,21 +1,52 @@
+import dataclasses
+import string
 from itertools import chain
+from typing import Dict, Optional, Tuple
+import calendar
+import datetime
 
-import numpy as np
+from dateutil.relativedelta import relativedelta
 
-from AnyQt.QtWidgets import QGridLayout
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import \
+    QGridLayout, QStyle, QComboBox, QLabel, QLineEdit, QSizePolicy
+from AnyQt.QtGui import QFontMetrics, QIntValidator
 
 from orangewidget.utils.widgetpreview import WidgetPreview
-from Orange.data import Table
-from Orange.widgets import widget, gui, settings
-from Orange.widgets.settings import DomainContextHandler
-from Orange.widgets.utils.itemmodels import VariableListModel
+
+from Orange.data import Table, TimeVariable
+from Orange.widgets import widget, gui
+from Orange.widgets.settings import Setting
+from Orange.widgets.utils.itemmodels import VariableListModel, signal_blocking
 from Orange.widgets.widget import Input, Output
 
-from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries import Timeseries, functions
+
+
+@dataclasses.dataclass
+class StepOptionsDef:
+    label: str
+    delta: Optional[relativedelta] = None
+    sub_daily: bool = False
+
+    def __post_init__(self):
+        if self.delta is None:
+            self.delta = relativedelta(**{self.label.lower(): 1})
+        self.sub_daily = not (self.delta.days or self.delta.weeks
+                              or self.delta.months or self.delta.years)
+
+
+StepOptions: Dict[str, relativedelta] = {
+    label: StepOptionsDef(label)
+    for label in ["Seconds", "Minutes", "Hours",
+                  "Days", "Weeks", "Months", "Years"]
+}
+StepOptions["Centuries"] = \
+    StepOptionsDef("Centuries", relativedelta(years=100))
 
 
 class OWTableToTimeseries(widget.OWWidget):
-    name = 'As Timeseries'
+    name = 'Form Timeseries'
     description = 'Reinterpret data table as a time series.'
     icon = 'icons/TableToTimeseries.svg'
     priority = 10
@@ -26,96 +57,255 @@ class OWTableToTimeseries(widget.OWWidget):
     class Outputs:
         time_series = Output("Time series", Timeseries)
 
+    class Error(widget.OWWidget.Error):
+        invalid_time = widget.Msg("Invalid time")
+        year_out_of_range = widget.Msg("{}.")
+
+    class Warning(widget.OWWidget.Warning):
+        nan_times = widget.Msg("Rows with missing values of '{}' are skipped")
+
     want_main_area = False
     resizing_enabled = False
 
-    # Old settings that can't be migrated, but can be supported
-    selected_attr = settings.Setting('')
-    radio_sequential = settings.Setting(2)
+    implied_sequence = Setting(0)
+    steps = Setting(1)
+    unit = Setting(next(iter(StepOptions)))
+    include_extra_part = Setting(True)
+    start_date = Setting((2022, 11, 1))
+    start_time = Setting((0, 0, 0))
+    attribute = Setting(None)
+    autocommit = Setting(True)
 
-    settingsHandler = DomainContextHandler()
-    implied_sequence = settings.ContextSetting(0)
-    order = settings.ContextSetting(None)
-    autocommit = settings.Setting(True)
-
-    class Information(widget.OWWidget.Information):
-        nan_times = widget.Msg('Some values of chosen sequential attribute '
-                               '"{}" are NaN, and have been omitted')
+    extra_part_labels = ["Include time of day in time stamp",
+                         "Include date in time stamp"]
 
     def __init__(self):
         self.data = None
 
-        layout = QGridLayout()
-        gui.widgetBox(self.controlArea, True, orientation=layout)
+        outbox = gui.vBox(self.controlArea, box=True)
+
+        style = self.style()
+        indent = style.pixelMetric(QStyle.PM_RadioButtonLabelSpacing) \
+            + style.pixelMetric(QStyle.PM_ExclusiveIndicatorWidth)
+        fmetr = QFontMetrics(self.font())
+        numwidth = max(fmetr.boundingRect(c).width() for c in string.digits)
+
         group = gui.radioButtons(
             None, self, 'implied_sequence', callback=self.commit.deferred)
-        layout.addWidget(
-            gui.appendRadioButton(
-                group, 'Sequential attribute:', addToLayout=False),
-            0, 0)
-        layout.addWidget(
-            gui.comboBox(
-                None, self, 'order', model=VariableListModel(),
-                callback=self._on_attribute_changed),
-            0, 1)
-        layout.addWidget(
-            gui.appendRadioButton(
-                group, 'Sequence implied by instance order', addToLayout=False),
-            1, 0, 1, 2)
+        gui.appendRadioButton(
+            group, "Select the column with date", insertInto=outbox)
+        hbox = gui.indentedBox(outbox, indent, orientation=Qt.Horizontal)
+        hbox.layout().addWidget(QLabel("Variable: "))
+        self.var_combo = combo = QComboBox()
+        combo.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        combo.setModel(VariableListModel())
+        combo.activated.connect(self._on_attribute_changed)
+        hbox.layout().addWidget(combo)
+        gui.separator(outbox, 16)
 
+        gui.appendRadioButton(
+            group, 'Sequence implied by instance order', insertInto=outbox)
+
+        calbox = gui.indentedBox(outbox, indent)
+        grid = QGridLayout()
+        gui.widgetBox(calbox, orientation=grid)
+
+        rows = 0
+        rows += self._add_step_controls(grid, rows, numwidth)
+        rows += self._add_format_controls(grid, rows)
+        rows += self._add_start_controls(grid, rows, numwidth)
         gui.auto_commit(self.controlArea, self, 'autocommit', '&Apply')
-        # TODO: seasonally adjust data (select attributes & season cycle length (e.g. 12 if you have monthly data))
+
+    def _add_start_controls(self, layout, row, numwidth):
+        layout.addWidget(QLabel("Start: "), row, 0)
+        self.datebox = gui.hBox(None)
+        y, m, d = self.start_date
+        numargs = dict(alignment=Qt.AlignCenter, maximumWidth=numwidth * 4)
+        self.date_edits = (
+            QLineEdit(str(y),
+                      alignment=Qt.AlignRight, maximumWidth=numwidth * 6),
+            combo := QComboBox(),
+            QLineEdit(str(d), **numargs)
+        )
+        combo.addItems(calendar.month_name[1:])
+        combo.setCurrentIndex(m)
+        combo.setMinimumContentsLength(max(map(len, calendar.month_name[1:])))
+        for edit in self.date_edits:
+            self.datebox.layout().addWidget(edit)
+        gui.rubber(self.datebox)
+        layout.addWidget(self.datebox, row, 1, 1, -1)
+
+        self.timebox = gui.hBox(None)
+        self.time_edits = tuple(
+            QLineEdit(f"{val:02}", **numargs)
+            for val in self.start_time)
+        for i, edit in enumerate(self.time_edits):
+            self.timebox.layout().addWidget(QLabel(["⏱", ":", ":"][i]))
+            self.timebox.layout().addWidget(edit)
+        gui.rubber(self.timebox)
+        layout.addWidget(self.timebox, row + 1, 1, 1, -1)
+
+        validator = QIntValidator()
+        for edit in chain(self.date_edits, self.time_edits):
+            if isinstance(edit, QLineEdit):
+                edit.setValidator(validator)
+                edit.editingFinished.connect(self._on_time_changed)
+            else:
+                edit.currentIndexChanged.connect(self._on_time_changed)
+
+        self._update_start_controls()
+        self.Error.invalid_time(shown=not self.is_valid_time())
+        return 2
+
+    def _update_start_controls(self):
+        self.controls.include_extra_part.setText(
+            self.extra_part_labels[StepOptions[self.unit].sub_daily])
+        self.timebox.setEnabled(self.use_time)
+        self.datebox.setEnabled(self.use_date)
+
+    def _add_step_controls(self, layout, row, numwidth):
+        layout.addWidget(QLabel("Step: "), row, 0)
+        box = gui.hBox(None)
+        le = gui.lineEdit(
+            box, self, "steps",
+            alignment=Qt.AlignRight, maximumWidth=4 * numwidth,
+            valueType=int, validator=QIntValidator(),
+        )
+        le.editingFinished.connect(self._on_time_settings_changed)
+        gui.comboBox(
+            box, self, "unit", items=list(StepOptions),
+            callback=self._on_time_settings_changed, sendSelectedValue=True
+        )
+        layout.addWidget(box, row, 1, 1, -1)
+        return 1
+
+    def _add_format_controls(self, layout, row):
+        layout.addWidget(
+            gui.checkBox(
+                None, self, "include_extra_part", self.extra_part_labels[0],
+                callback=self._on_time_settings_changed), row, 1, 1, -1)
+        return 1
+
+    @property
+    def use_time(self):
+        return self.include_extra_part or StepOptions[self.unit].sub_daily
+
+    @property
+    def use_date(self):
+        return self.include_extra_part or not StepOptions[self.unit].sub_daily
 
     def _on_attribute_changed(self):
         self.implied_sequence = 0
         self.commit.deferred()
 
+    def _on_time_settings_changed(self):
+        self.implied_sequence = 1
+        self._update_start_controls()
+        self.commit.deferred()
+
+    def _on_time_changed(self):
+        self.implied_sequence = 1
+        self.read_start_time()
+        self.commit.deferred()
+
+    def read_start_time(self) -> Optional[Tuple[int, int, int, int, int, int]]:
+        ye, me, de = self.date_edits
+        self.start_date = (int(ye.text()), me.currentIndex() + 1, int(de.text()))
+        self.start_time = tuple(int(edit.text()) for edit in self.time_edits)
+
+    def get_time(self):
+        return (self.start_date if self.use_date else (1970, 1, 1)) \
+            + (self.start_time if self.use_time else (0, 0, 0))
+
+    def is_valid_time(self):
+        y, m, d, ho, mi, se = self.get_time()
+        _, days_in_month = calendar.monthrange(y, m)
+        return 1 <= d <= days_in_month \
+               and 0 <= ho < 24 and 0 <= mi < 60 and 0 <= se < 60
+
     @Inputs.data
     def set_data(self, data):
-        self.closeContext()
-        self.data = data
-        model = self.controls.order.model()
-        if data:
-            valid = (var
-                     for var in chain(data.domain.variables, data.domain.metas)
-                     if var.is_continuous)
-            model[:] = sorted(valid, key=lambda var: not var.is_time)
-        else:
-            model.clear()
+        if not data:
+            self.data = None
+            self.var_combo.model().clear()
+            self.commit.now()
+            return
 
-        if not model:
-            self.implied_sequence = 1
-        # radio_sequential and selected_attr can't be migrated, but can be used
-        elif self.radio_sequential != 2:
-            self.implied_sequence = self.radio_sequential
-        if model:
-            if self.selected_attr in data.domain \
-                    and data.domain[self.selected_attr] in model:
-                self.order = data.domain[self.selected_attr]
-            else:
-                self.order = getattr(data, "time_variable", model[0])
-        self.controls.implied_sequence.buttons[0].setDisabled(not model)
-        self.openContext(data)
+        with signal_blocking(self.var_combo):
+            model = self.var_combo.model()
+            self.data = data
+            time_vars = [
+                var for var in chain(data.domain.variables, data.domain.metas)
+                if var.is_time]
+            cont_vars = [
+                var for var in chain(data.domain.variables, data.domain.metas)
+                if var.is_continuous and not var.is_time]
+            separator = [VariableListModel.Separator
+                         ] if len(time_vars) > 1 and cont_vars else []
+            model[:] = time_vars + separator + cont_vars
+
+            self.controls.implied_sequence.buttons[0].setDisabled(not model)
+            if not model:
+                self.implied_sequence = 1
+            if model and self.attribute not in [var.name
+                                                for var in time_vars + cont_vars]:
+                self.attribute = getattr(data, "time_variable", model[0]).name
         self.commit.now()
 
     @gui.deferred
     def commit(self):
-        data = self.data
-        self.Information.clear()
-        if not data:
-            self.Outputs.time_series.send(None)
-            return
-
-        if self.order is None:
-            ts = Timeseries.make_timeseries_from_sequence(data)
+        self.Warning.clear()
+        self.Error.year_out_of_range.clear()
+        self.Error.invalid_time.clear()
+        if not self.data:
+            ts = None
+        elif self.implied_sequence == 0:
+            ts = self._series_from_variable()
         else:
-            ts = Timeseries.make_timeseries_from_continuous_var(data, self.order)
-            # Warn if instances are omitted because of nans in selected attr
-            times = data.get_column(self.order)
-            if np.isnan(times).any():
-                self.Information.nan_times(self.order.name)
-
+            ts = self._series_by_sequence()
         self.Outputs.time_series.send(ts)
+
+    def _series_from_variable(self):
+        data = self.data
+        time_var = data.domain[self.attribute]
+        ts = Timeseries.make_timeseries_from_continuous_var(data, time_var)
+        self.Warning.nan_times(self.attribute,
+                               shown=ts is None or len(data) != len(ts))
+        return ts
+
+    def _series_by_sequence(self):
+        if not self.is_valid_time():
+            self.Error.invalid_time()
+            return None
+
+        start = datetime.datetime(*self.get_time(), 0, datetime.timezone.utc)
+        delta = int(self.steps) * StepOptions[self.unit].delta
+        try:
+            ts = Timeseries.make_timeseries_from_sequence(
+                self.data, delta, start,
+                have_date=self.use_date, have_time=self.use_time)
+        except ValueError as exc:
+            msg = str(exc)
+            if msg.startswith("year") and msg.endswith("out of range"):
+                self.Error.year_out_of_range(msg.capitalize())
+                return None
+            else:
+                raise
+        return ts
+
+    def send_report(self):
+        if self.implied_sequence == 0:
+            self.report_items((("Assigned time variable", self.attribute), ))
+        else:
+            timevar = TimeVariable(
+                "foo", have_date=self.use_date, have_time=self.use_time)
+            start_time = timevar.str_val(
+                functions.timestamp(datetime.datetime(*self.get_time(),
+                                    0, datetime.timezone.utc)))
+            self.report_items((
+                ("Start time", start_time),
+                ("Step", f"{self.steps} {self.unit.lower()}")
+            ))
 
 
 if __name__ == "__main__":

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -1,95 +1,566 @@
+from itertools import chain
+from datetime import datetime, timezone
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import scipy.sparse as sp
 
-from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
+from AnyQt.QtWidgets import QLineEdit
+
+from Orange.data import \
+    Table, Domain, DiscreteVariable, ContinuousVariable, TimeVariable
 from Orange.widgets.tests.base import WidgetTest
 
-from orangecontrib.timeseries import Timeseries
-from orangecontrib.timeseries.widgets.owtabletotimeseries import OWTableToTimeseries
+from orangecontrib.timeseries.functions import timestamp
+from orangecontrib.timeseries.widgets.owtabletotimeseries import \
+    OWTableToTimeseries
 
 
-class TestAsTimeSeriesWidget(WidgetTest):
+class TestAsTimeSeriesWidgetBase(WidgetTest):
     def setUp(self):
-        self.widget = self.create_widget(OWTableToTimeseries)  # type: OWTableToTimeseries
-
-    def test_time_as_metas(self):
-        """
-        As Timeseries should accept attributes from X and metas.
-        """
-        w = self.widget
-        data = Table.from_url("http://file.biolab.si/datasets/cyber-security-breaches.tab")[:20]
-        self.send_signal(w.Inputs.data, data)
-        model = w.controls.order.model()
-        self.assertEqual(len(model), 4)
-        new_domain = Domain(data.domain[:6], metas=[data.domain[6]])
-        new_data = Table.from_table(new_domain, data)
-        self.send_signal(w.Inputs.data, new_data)
-        self.assertEqual(len(model), 4)
-
-    def test_timeseries_column_nans(self):
-        """
-        When cannot create Timeseries make sure output is None.
-        GH-30
-        """
-        w = self.widget
-        data = Table("iris")[:2].copy()
-        self.assertFalse(w.Information.nan_times.is_shown())
-        self.send_signal(w.Inputs.data, data)
-        self.assertFalse(w.Information.nan_times.is_shown())
-        self.assertIsInstance(self.get_output(w.Outputs.time_series), Timeseries)
-        with data.unlocked():
-            data.X[:, 0] = np.nan
-        self.send_signal(w.Inputs.data, data)
-        self.assertTrue(w.Information.nan_times.is_shown())
-        self.assertIsNone(self.get_output(w.Outputs.time_series))
-
-    def test_timeserise_sparse(self):
-        widget = self.widget
-        widget.radio_sequential = 0
+        self.widget: OWTableToTimeseries = self.create_widget(OWTableToTimeseries)
 
         x, y, m = (ContinuousVariable(n) for n in "xym")
         domain = Domain(
             [DiscreteVariable("a", values=tuple("abc")), x, y],
-            DiscreteVariable("c"),
-            [m])
-        xs = sp.csr_matrix([[0, 1, 0], [2, 0, np.nan], [0, -1, 2]])
-        ys = sp.csr_matrix([[0], [1], [np.nan]])
-        ms = sp.csr_matrix([[0], [3], [np.nan]])
-        data = Table.from_numpy(domain, xs, ys, ms)
+            DiscreteVariable("c", values=tuple("ab")),
+            [m,
+             TimeVariable("t", have_time=True),
+             TimeVariable("u", have_date=True, have_time=True)])
+        self.data = Table.from_numpy(
+            domain,
+            np.array([[0, 1, 0],
+                      [2, 0, np.nan],
+                      [0, -1, 2],
+                      [np.nan, 3.1, 2.7]]),
+            np.array([0, 1, np.nan, 0]),
+            np.array([[0, 2, 1667471775.0],  # 2022-11-03 10:36:15
+                      [3, np.nan, -1613826000.0],  # 1918-11-11 11:00
+                      [np.nan, 3600, np.nan],
+                      [1.18, 1805, 677808000.0]  # 1991-06-25
+                      ])
+        )
+
+
+# Old tests, which are unspecific but can still catch something
+class TestAsTimeSeriesWidgetOld(TestAsTimeSeriesWidgetBase):
+    def test_basic_output(self):
+        w = self.widget
+        w.implied_sequence = 0
+        self.send_signal(w.Inputs.data, self.data)
+        model = w.var_combo.model()
+        self.assertEqual(len(model), 6)
+        out = self.get_output(w.Outputs.time_series)
+        self.assertIs(out.time_variable, self.data.domain.metas[1])
+        np.testing.assert_equal(out.time_values, [2, 1805, 3600])
+
+    def test_no_output_when_all_nan(self):
+        w = self.widget
+        w.implied_sequence = 0
+        with self.data.unlocked():
+            self.data.metas[:, 1] = np.nan
+        self.send_signal(w.Inputs.data, self.data)
+        self.assertTrue(w.Warning.nan_times.is_shown())
+        self.assertIsNone(self.get_output(w.Outputs.time_series))
+
+    def test_sparse_data(self):
+        widget = self.widget
+        widget.implied_sequence = 0
+
+        data = self.data
+        with data.unlocked():
+            data.X = sp.csr_matrix(data.X)
+            data.Y = sp.csr_matrix(data.Y)
+            data.metas = sp.csr_matrix(data.metas.astype(float))
         self.send_signal(widget.Inputs.data, data)
 
-        widget.order = x
+        widget.attribute = "x"
         widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
-            out.X, [[0, -1, 2], [2, 0, np.nan], [0, 1, 0]])
+            out.X,
+            [[0, -1, 2], [2, 0, np.nan], [0, 1, 0], [np.nan, 3.1, 2.7]])
 
-        widget.order = y
+        widget.attribute = "y"
         widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
-            out.X, [[0, 1, 0], [0, -1, 2]])
-        self.assertTrue(widget.Information.nan_times.is_shown())
+            out.X, [[0, 1, 0], [0, -1, 2], [np.nan, 3.1, 2.7]])
+        self.assertTrue(widget.Warning.nan_times.is_shown())
 
-        widget.order = m
+        widget.attribute = "m"
         widget.commit.now()
         out = self.get_output(widget.Outputs.time_series)
         np.testing.assert_equal(
-            out.X, [[0, 1, 0], [2, 0, np.nan]])
-        self.assertTrue(widget.Information.nan_times.is_shown())
+            out.X, [[0, 1, 0], [np.nan, 3.1, 2.7], [2, 0, np.nan]])
+        self.assertTrue(widget.Warning.nan_times.is_shown())
 
-        widget.order = x
+        widget.attribute = "x"
         widget.commit.now()
-        self.assertFalse(widget.Information.nan_times.is_shown())
+        self.assertFalse(widget.Warning.nan_times.is_shown())
 
-        widget.order = m
+        widget.attribute = "m"
         widget.commit.now()
-        self.assertTrue(widget.Information.nan_times.is_shown())
+        self.assertTrue(widget.Warning.nan_times.is_shown())
 
         self.send_signal(widget.Inputs.data, None)
-        self.assertFalse(widget.Information.nan_times.is_shown())
+        self.assertFalse(widget.Warning.nan_times.is_shown())
+
+
+class TestAsTimeSeriesWidget(TestAsTimeSeriesWidgetBase):
+    def test_var_model(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        self.assertEqual(w.var_combo.model().rowCount(), 6)
+
+        domain = self.data.domain
+        c2t2 = Domain(domain.attributes[2:], domain.class_vars, domain.metas)
+        self.send_signal(w.Inputs.data, self.data.transform(c2t2))
+        self.assertEqual(w.var_combo.model().rowCount(), 5)
+
+        c1t2 = Domain([], domain.class_vars, domain.metas)
+        self.send_signal(w.Inputs.data, self.data.transform(c1t2))
+        self.assertEqual(w.var_combo.model().rowCount(), 4)
+
+        c0t2 = Domain([], domain.class_vars, domain.metas[1:])
+        self.send_signal(w.Inputs.data, self.data.transform(c0t2))
+        self.assertEqual(w.var_combo.model().rowCount(), 2)  # no separator
+
+        c2t1 = Domain(domain.attributes, domain.class_vars, domain.metas[2:])
+        self.send_signal(w.Inputs.data, self.data.transform(c2t1))
+        self.assertEqual(w.var_combo.model().rowCount(), 3)  # no separator
+
+        c2t0 = Domain(domain.attributes, domain.class_vars, [])
+        self.send_signal(w.Inputs.data, self.data.transform(c2t0))
+        self.assertEqual(w.var_combo.model().rowCount(), 2)  # no separator
+
+    def test_attribute_changed(self):
+        w = self.widget
+        w.implied_sequence = 1
+
+        self.send_signal(w.Inputs.data, Table("iris"))
+        with patch.object(w.commit, 'deferred') as commit:
+            w.var_combo.setCurrentIndex(2)
+            w.var_combo.activated.emit(2)
+            self.assertEqual(w.implied_sequence, 0)
+            commit.assert_called_once()
+
+    def test_attribute_changed(self):
+        w = self.widget
+        w.implied_sequence = 1
+
+        self.send_signal(w.Inputs.data, Table("iris"))
+        with patch.object(w.commit, 'deferred') as commit:
+            w.var_combo.setCurrentIndex(2)
+            w.var_combo.activated.emit(2)
+            self.assertEqual(w.implied_sequence, 0)
+            commit.assert_called_once()
+
+    def test_time_settings_changed_and_update_interface(self):
+        w = self.widget
+
+        unit_combo = w.controls.unit
+        step_line = w.controls.steps
+        extra_cb = w.controls.include_extra_part
+        self.send_signal(w.Inputs.data, Table("iris"))
+
+        with patch.object(w.commit, 'deferred') as commit:
+            w.include_extra_part = False
+
+            w.implied_sequence = 0
+            w.unit = 0
+            unit_combo.textActivated.emit(unit_combo.itemText(0))
+            self.assertEqual(w.implied_sequence, 1)
+            commit.assert_called_once()
+            self.assertFalse(w.datebox.isEnabled())
+            self.assertTrue(w.timebox.isEnabled())
+            commit.reset_mock()
+
+            w.implied_sequence = 0
+            w.unit = 4
+            unit_combo.textActivated.emit(unit_combo.itemText(4))
+            self.assertEqual(w.implied_sequence, 1)
+            commit.assert_called_once()
+            self.assertTrue(w.datebox.isEnabled())
+            self.assertFalse(w.timebox.isEnabled())
+            commit.reset_mock()
+
+            w.implied_sequence = 0
+            self.include_extra_part = True
+            extra_cb.toggled.emit(True)
+            self.assertEqual(w.implied_sequence, 1)
+            commit.assert_called_once()
+            self.assertTrue(w.datebox.isEnabled())
+            self.assertTrue(w.timebox.isEnabled())
+            commit.reset_mock()
+
+            w.implied_sequence = 0
+            w.unit = 0
+            unit_combo.textActivated.emit(unit_combo.itemText(0))
+            self.assertEqual(w.implied_sequence, 1)
+            commit.assert_called_once()
+            self.assertTrue(w.datebox.isEnabled())
+            self.assertTrue(w.timebox.isEnabled())
+            commit.reset_mock()
+
+            w.implied_sequence = 0
+            self.include_extra_part = False
+            extra_cb.toggled.emit(False)
+            self.assertEqual(w.implied_sequence, 1)
+            commit.assert_called_once()
+            self.assertFalse(w.datebox.isEnabled())
+            self.assertTrue(w.timebox.isEnabled())
+            commit.reset_mock()
+
+            w.implied_sequence = 0
+            step_line.editingFinished.emit()
+            commit.assert_called_once()
+
+    def test_on_time_changed_callbacks(self):
+        w = self.widget
+        with patch.object(w.commit, 'deferred') as commit:
+            for edit in chain(w.date_edits, w.time_edits):
+                w.implied_sequence = 0
+                if isinstance(edit, QLineEdit):
+                    edit.editingFinished.emit()
+                else:
+                    edit.currentIndexChanged.emit(0)
+                self.assertEqual(w.implied_sequence, 1, str(edit))
+                commit.assert_called_once()
+                commit.reset_mock()
+
+    def test_time_reading_and_validation(self):
+        w = self.widget
+        # Dates before 2020 have invalid date
+        # 2020 is correct
+        # Dates after 2020 have invalid time
+        for time in ((2020, 2, 29, 23, 59, 59),
+                     (1970, 1, 32, 0, 0, 0),
+                     (1917, 2, 29, 0, 0, 0),
+                     (2016, 2, 30, 0, 0, 0),
+                     (2022, 11, 2, 24, 0, 0),
+                     (2022, 11, 2, 23, 60, 0),
+                     (2022, 11, 2, 23, 0, 60)):
+            for val, edit in zip(time, chain(w.date_edits, w.time_edits)):
+                if isinstance(edit, QLineEdit):
+                    edit.setText(str(val))
+                else:
+                    edit.setCurrentIndex(val - 1)
+
+            w.include_extra_part = True
+            w.read_start_time()
+            self.assertEqual(w.start_date, time[:3])
+            self.assertEqual(w.start_time, time[3:])
+            self.assertIs(w.is_valid_time(), time[0] == 2020)
+            self.assertEqual(w.get_time(), w.start_date + w.start_time)
+
+            w.include_extra_part = False
+            w.unit = w.controls.unit.itemText(0)
+            # read_start_time still reads all
+            w.read_start_time()
+            self.assertEqual(w.start_date, time[:3])
+            self.assertEqual(w.start_time, time[3:])
+            # Zero start date
+            self.assertEqual(w.get_time(), (1970, 1, 1) + w.start_time)
+            # Those before 2020 have invalid date
+            self.assertIs(w.is_valid_time(), time[0] != 2022)
+
+            w.include_extra_part = False
+            w.unit = w.controls.unit.itemText(5)
+            # read_start_time still reads all
+            w.read_start_time()
+            self.assertEqual(w.start_date, time[:3])
+            self.assertEqual(w.start_time, time[3:])
+            # Zero start time
+            self.assertEqual(w.get_time(), w.start_date + (0, 0, 0))
+            # Dates after 2020 have invalid time
+            self.assertIs(w.is_valid_time(), time[0] >= 2020)
+
+    def test_set_data(self):
+        w = self.widget
+        w.implied_sequence = 0
+
+        with patch.object(w.commit, 'now') as commit:
+            self.send_signal(w.Inputs.data, Table("iris"))
+            self.assertEqual(len(w.var_combo.model()), 4)
+            self.assertEqual(w.attribute, "sepal length")
+            w.attribute = "petal length"
+            commit.assert_called_once()
+            commit.reset_mock()
+
+            self.send_signal(w.Inputs.data, None)
+            self.assertEqual(len(w.var_combo.model()), 0)
+            self.assertEqual(w.attribute, "petal length")  # Kept as hint!
+            commit.assert_called_once()
+            commit.reset_mock()
+
+            self.send_signal(w.Inputs.data, Table("iris"))
+            self.assertEqual(len(w.var_combo.model()), 4)
+            self.assertEqual(w.attribute, "petal length")
+            commit.assert_called_once()
+            commit.reset_mock()
+
+            # All of above shouldn't have switched to `implied_sequence`
+            self.assertEqual(w.implied_sequence, 0)
+
+            self.send_signal(w.Inputs.data, Table("zoo"))
+            self.assertEqual(w.implied_sequence, 1)
+            self.assertEqual(len(w.var_combo.model()), 0)
+            self.assertEqual(w.attribute, "petal length")
+            self.assertEqual(w.implied_sequence, 1)
+            self.assertFalse(w.controls.implied_sequence.buttons[0].isEnabled())
+            commit.assert_called_once()
+            commit.reset_mock()
+
+    def test_series_from_variable(self):
+        w = self.widget
+        w.implied_sequence = 0
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.attribute = "x"
+        ts = w._series_from_variable()
+        np.testing.assert_equal(
+            ts.X,
+            [[0., -1., 2.],
+             [2., 0., np.nan],
+             [0., 1., 0.],
+             [np.nan, 3.1, 2.7]])
+        self.assertFalse(w.Warning.nan_times.is_shown())
+
+        w.attribute = "y"
+        ts = w._series_from_variable()
+        np.testing.assert_equal(
+            ts.X,
+            [[0., 1., 0.],
+             [0., -1., 2.],
+             [np.nan, 3.1, 2.7]])
+        self.assertTrue(w.Warning.nan_times.is_shown())
+
+        w.attribute = "m"
+        ts = w._series_from_variable()
+        np.testing.assert_equal(
+            ts.X,
+            [[0., 1., 0.],
+             [np.nan, 3.1, 2.7],
+             [2., 0., np.nan]])
+
+    def test_series_by_sequence(self):
+        def assert_stamps(stamps, offset):
+            stamps = np.asarray(stamps)
+            offset = timestamp(datetime(*offset, 0, timezone.utc))
+            ts = w._series_by_sequence()
+            np.testing.assert_equal(ts.time_values, stamps + offset)
+
+        w = self.widget
+        w.implied_sequence = 1
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.start_date = (2022, 11, 3)
+        w.start_time = (11, 13, 45)
+
+        w.include_extra_part = False
+        w.unit = "Seconds"
+        w.steps = 1
+        assert_stamps(np.arange(4), (1970, 1, 1, 11, 13, 45))
+
+        w.unit = "Seconds"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8, (1970, 1, 1, 11, 13, 45))
+
+        w.unit = "Minutes"
+        w.steps = 1
+        assert_stamps(np.arange(4) * 60, (1970, 1, 1, 11, 13, 45))
+
+        w.unit = "Minutes"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8 * 60, (1970, 1, 1, 11, 13, 45))
+
+        w.unit = "Hours"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8 * 3600, (1970, 1, 1, 11, 13, 45))
+
+        w.unit = "Days"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8 * 3600 * 24, (2022, 11, 3, 0, 0, 0))
+
+        w.unit = "Months"
+        w.steps = 1
+        np.testing.assert_equal(
+            [timestamp(datetime(2022, 11, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2022, 12, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2023, 1, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2023, 2, 3, 0, 0, 0, 0, timezone.utc))],
+            w._series_by_sequence().time_values
+        )
+
+        w.unit = "Months"
+        w.steps = 3
+        np.testing.assert_equal(
+            [timestamp(datetime(2022, 11, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2023, 2, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2023, 5, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2023, 8, 3, 0, 0, 0, 0, timezone.utc))],
+            w._series_by_sequence().time_values
+        )
+
+        w.unit = "Years"
+        w.steps = 3
+        np.testing.assert_equal(
+            [timestamp(datetime(2022, 11, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2025, 11, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2028, 11, 3, 0, 0, 0, 0, timezone.utc)),
+             timestamp(datetime(2031, 11, 3, 0, 0, 0, 0, timezone.utc))],
+            w._series_by_sequence().time_values
+        )
+
+        w.include_extra_part = True
+        w.unit = "Seconds"
+        w.steps = 1
+        assert_stamps(np.arange(4), (2022, 11, 3, 11, 13, 45))
+
+        w.unit = "Seconds"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8, (2022, 11, 3, 11, 13, 45))
+
+        w.unit = "Minutes"
+        w.steps = 1
+        assert_stamps(np.arange(4) * 60, (2022, 11, 3, 11, 13, 45))
+
+        w.unit = "Minutes"
+        w.steps = 8
+        assert_stamps(np.arange(4) * 8 * 60, (2022, 11, 3, 11, 13, 45))
+
+        w.unit = "Months"
+        w.steps = 3
+        np.testing.assert_equal(
+            [timestamp(datetime(2022, 11, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2023, 2, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2023, 5, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2023, 8, 3, 11, 13, 45, 0, timezone.utc))],
+            w._series_by_sequence().time_values
+        )
+
+        w.unit = "Years"
+        w.steps = 3
+        np.testing.assert_equal(
+            [timestamp(datetime(2022, 11, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2025, 11, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2028, 11, 3, 11, 13, 45, 0, timezone.utc)),
+             timestamp(datetime(2031, 11, 3, 11, 13, 45, 0, timezone.utc))],
+            w._series_by_sequence().time_values
+        )
+
+    def test_series_by_sequence_invalid_date(self):
+        w = self.widget
+        errtime = w.Error.invalid_time
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.start_date = (2022, 11, 3)
+        w.start_time = (11, 13, 45)
+
+        # All fine
+        w.include_extra_part = False
+        self.assertIsNotNone(w._series_by_sequence())
+        self.assertFalse(errtime.is_shown())
+
+        # Date is invalid, but ignored -- should be fine
+        w.unit = "Hours"
+        w.start_date = (2022, 11, 31)
+        self.assertIsNotNone(w._series_by_sequence())
+        self.assertFalse(errtime.is_shown())
+
+        # Time is invalid
+        w.start_time = (11, 60, 45)
+        self.assertIsNone(w._series_by_sequence())
+        self.assertTrue(errtime.is_shown())
+        errtime.clear()  # Errors are cleared by commit, not _series_by_sequence
+
+        # Date is valid; time is invalid but ignored
+        w.unit = "Days"
+        w.start_date = (2022, 11, 3)
+        w.start_time = (11, 60, 45)
+        self.assertIsNotNone(w._series_by_sequence())
+        self.assertFalse(errtime.is_shown())
+
+        # Date is invalid
+        w.start_date = (2022, 11, 31)
+        self.assertIsNone(w._series_by_sequence())
+        self.assertTrue(errtime.is_shown())
+        errtime.clear()  # Errors are cleared by commit, not _series_by_sequence
+
+        w.include_extra_part = True
+
+        # Date is invalid, time is invalid and *not* ignored
+        w.start_date = (2022, 11, 3)
+        w.start_time = (11, 60, 45)
+        self.assertIsNone(w._series_by_sequence())
+        self.assertTrue(errtime.is_shown())
+        errtime.clear()  # Errors are cleared by commit, not _series_by_sequence
+
+        # Date is invalid, time is invalid and *not* ignored
+        w.unit = "Hours"
+        w.start_date = (2022, 11, 31)
+        w.start_time = (11, 59, 45)
+        self.assertIsNone(w._series_by_sequence())
+        self.assertTrue(errtime.is_shown())
+
+    def test_series_by_sequence_year_out_of_range(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.unit = "Years"
+        w.steps = 10000
+        w.start_date = (2022, 11, 3)
+        w.start_time = (11, 13, 45)
+
+        self.assertIsNone(w._series_by_sequence())
+        self.assertTrue(w.Error.year_out_of_range.is_shown())
+
+    def test_series_by_sequence_time_format(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.unit = "Hours"
+
+        w.include_extra_part = False
+        ts = w._series_by_sequence()
+        self.assertEqual(ts.time_variable.have_date, 0)
+        self.assertEqual(ts.time_variable.have_time, 1)
+
+        w.include_extra_part = True
+        ts = w._series_by_sequence()
+        self.assertEqual(ts.time_variable.have_date, 1)
+        self.assertEqual(ts.time_variable.have_time, 1)
+
+        w.unit = "Days"
+
+        w.include_extra_part = False
+        ts = w._series_by_sequence()
+        self.assertEqual(ts.time_variable.have_date, 1)
+        self.assertEqual(ts.time_variable.have_time, 0)
+
+        w.include_extra_part = True
+        ts = w._series_by_sequence()
+        self.assertEqual(ts.time_variable.have_date, 1)
+        self.assertEqual(ts.time_variable.have_time, 1)
+
+    def test_series_by_sequence_reraises_exceptions(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        with patch("orangecontrib.timeseries.Timeseries."
+                   "make_timeseries_from_sequence", side_effect=ValueError):
+            self.assertRaises(ValueError, w._series_by_sequence)
+
+    def test_report(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+
+        w.implied_sequence = 0
+        w.send_report()
+
+        w.implied_sequence = 1
+        w.send_report()
 
 
 if __name__ == "__main__":

--- a/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owtabletotimeseries.py
@@ -8,7 +8,8 @@ import numpy as np
 import scipy.sparse as sp
 
 from AnyQt.QtWidgets import QLineEdit
-from AnyQt.QtGui import QFocusEvent
+from AnyQt.QtCore import Qt, QPointF, QPoint
+from AnyQt.QtGui import QMouseEvent
 
 from Orange.data import \
     Table, Domain, DiscreteVariable, ContinuousVariable, TimeVariable
@@ -230,7 +231,10 @@ class TestAsTimeSeriesWidget(TestAsTimeSeriesWidgetBase):
             for edit in chain(w.date_edits, w.time_edits):
                 w.implied_sequence = 0
                 if isinstance(edit, QLineEdit):
-                    edit.focusInEvent(QFocusEvent(QFocusEvent.FocusIn))
+                    edit.mousePressEvent(QMouseEvent(
+                        QMouseEvent.MouseButtonPress,
+                        QPointF(3, 3), edit.mapToGlobal(QPoint(3, 3)),
+                        Qt.LeftButton, Qt.LeftButton, Qt.NoModifier))
                 else:
                     edit.currentIndexChanged.emit(0)
                 self.assertEqual(w.implied_sequence, 1, str(edit))

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
         install_requires=[
             'Orange3>=3.33.0',
             'statsmodels>=0.13.0',
+            'python-dateutil',
             'pandas',  # statsmodels requires this but doesn't have it in dependencies?
             'pandas_datareader',
             'numpy',


### PR DESCRIPTION
##### Issue

- Fixes #239 - reimplementation of `TimeSeries`.
- Also: monkey patch `get_column` into `Table` if necessary, and use `get_column` instead of `get_column_view`.
- Also: Fixes #165 by fixing `Timeseries.from_data_table` and reimplementing `copy` and `__getitem__`.

##### Description of changes

<img width="435" alt="Screen Shot 2022-11-03 at 13 15 09" src="https://user-images.githubusercontent.com/2387315/199718056-039da019-162f-4252-8edc-eec1ae2bf674.png">

This changes the previous functionality because it always adds a variable. Should the user have an option to remove it? On the other hand, one could consider previous functionality broken because it allowed constructing a `TimeSeries` with `time_variable == None` (which was in fact unexpected and broke some widgets).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
