### PR TITLE
Correlogram: Include parameters in cache key

### DIFF
--- a/orangecontrib/timeseries/widgets/owcorrelogram.py
+++ b/orangecontrib/timeseries/widgets/owcorrelogram.py
@@ -36,11 +36,12 @@ class OWCorrelogram(OWPeriodBase):
                      callback=self.replot)
 
     def acf(self, attr, pacf, confint):
-        if attr not in self._cached:
+        key = (attr, pacf, confint)
+        if key not in self._cached:
             x = self.data.interp(attr).ravel()
             func = partial_autocorrelation if pacf else autocorrelation
-            self._cached[attr] = func(x, alpha=.05 if confint else None)
-        return self._cached[attr]
+            self._cached[key] = func(x, alpha=.05 if confint else None)
+        return self._cached[key]
 
     def replot(self):
         self.plot.clear()


### PR DESCRIPTION
##### Issue

@StatViser reported that changing the partial correlation checkbox has no effect.

##### Description of changes

The widget cached computed correlations using just the attribute - but not also parameters! - as the key. Parameters are now included in the key.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
