### PR TITLE
[FIX] ARIMA - remove use_exog

### DIFF
--- a/orangecontrib/timeseries/widgets/owarimamodel.py
+++ b/orangecontrib/timeseries/widgets/owarimamodel.py
@@ -20,7 +20,6 @@ class OWARIMAModel(OWBaseModel):
     p = settings.Setting(1)
     d = settings.Setting(0)
     q = settings.Setting(0)
-    use_exog = settings.Setting(False)
 
     class Inputs(OWBaseModel.Inputs):
         exogenous_data = Input("Exogenous data", Timeseries)
@@ -47,15 +46,13 @@ class OWARIMAModel(OWBaseModel):
                       gui.spin(None, self, 'q', 0, 100, **kwargs))
 
     def forecast(self, model):
-        if self.use_exog and self.exog_data is None:
-            return
         return model.predict(self.forecast_steps,
                              exog=self.exog_data,
                              alpha=1 - self.forecast_confint / 100,
                              as_table=True)
 
     def create_learner(self):
-        return ARIMA((self.p, self.d, self.q), self.use_exog)
+        return ARIMA((self.p, self.d, self.q), self.exog_data is not None)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/timeseries/widgets/tests/test_OWARIMAModel.py
+++ b/orangecontrib/timeseries/widgets/tests/test_OWARIMAModel.py
@@ -1,0 +1,33 @@
+import unittest
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.timeseries import Timeseries
+from orangecontrib.timeseries.widgets.owarimamodel import OWARIMAModel
+
+
+class TestCorrelogramWidget(WidgetTest):
+    def setUp(self):
+        self.widget: OWARIMAModel = self.create_widget(OWARIMAModel)
+        self.data = Timeseries.from_file("airpassengers")
+
+    def test_data(self):
+        self.send_signal(self.widget.Inputs.time_series, self.data)
+        output = self.get_output(self.widget.Outputs.forecast)
+        self.assertEqual(3, len(output))
+        self.assertIsNotNone(self.widget.Outputs.learner)
+        self.assertIsNotNone(self.widget.Outputs.fitted_values)
+        self.assertIsNotNone(self.widget.Outputs.residuals)
+
+    def test_exog_data(self):
+        self.send_signal(self.widget.Inputs.time_series, self.data)
+        self.send_signal(self.widget.Inputs.exogenous_data, self.data[:3, :1])
+        output = self.get_output(self.widget.Outputs.forecast)
+        self.assertEqual(3, len(output))
+        self.assertIsNotNone(self.widget.Outputs.learner)
+        self.assertIsNotNone(self.widget.Outputs.fitted_values)
+        self.assertIsNotNone(self.widget.Outputs.residuals)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In https://github.com/biolab/orange3-timeseries/pull/235 `Use exogenous data` was removed. I guess it was removed since widget can use them always when they are present on the input and not use them when their input is None. This change didn't remove the `self. use_exog` variable and its use. It can cause an error in model fitting when it is still remembered in Orange's setting as True. The other error is that it is still passed to the model even if it cannot be set.

##### Description of changes
Remove `self. use_exog` and pass True to the model if exog data on input, False otherwise.
Simple tests.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
