### PR TITLE
Annotate graph_name with graph's types

### DIFF
--- a/orangecontrib/timeseries/widgets/owlinechart.py
+++ b/orangecontrib/timeseries/widgets/owlinechart.py
@@ -615,7 +615,7 @@ class OWLineChart(OWWidget):
     plot_type: List[str] = ContextSetting([])
 
     settings_version = 2
-    graph_name = "_graph"
+    graph_name = "_graph"  # QGraphicsView (pg.GraphicsLayoutWidget -> LineChartGraph)
 
     MAX_PLOTS = 5
 

--- a/orangecontrib/timeseries/widgets/owperiodbase.py
+++ b/orangecontrib/timeseries/widgets/owperiodbase.py
@@ -25,7 +25,7 @@ class OWPeriodBase(OWWidget, openclass=True):
     # context handler.
     selection: List[str] = Setting([], schema_only=True)
 
-    graph_name = 'plot'
+    graph_name = 'plot'  # pg.GraphicsItem (pg.PlotItem)
 
     class Error(OWWidget.Error):
         no_instances = Msg("Data contains just a single instance")

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -471,7 +471,7 @@ class OWSpiralogram(OWWidget):
     class Error(OWWidget.Error):
         no_useful_vars = Msg("Data has no useful variables")
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
 
     settingsHandler = SpiralogramContextHandler()
     x_var: Union[str, Variable] = ContextSetting(PeriodItems[0])


### PR DESCRIPTION
##### Issue

We don't know which object types are passed to methods for reporting, saving charts and copying to clipboard.

##### Description of changes

- Added comments with one of the four types handled by `ImgFormat` (`pg.GraphicsItem`, `QGraphicsScene`, `QGraphicsView`, `QWidget`), and the actual derived type, if applicable.
