### PR TITLE
Spiralogram, Moving Transform: Add week of year

### DIFF
--- a/doc/widgets/moving_transform_w.md
+++ b/doc/widgets/moving_transform_w.md
@@ -20,7 +20,7 @@ Compute aggregations over a sliding window, consecutive blocks or time periods o
    - *Consecutive blocks*: aggregates data within consecutive blocks
       - *Block width*: the number of instances in block
       - Data output: *Discard original data* will output only aggregated columns; *Keep first instance*, *Keep middle instance* and *Keep last instance* will take the first, middle or last data instance as the representative for the block.
-   - *Aggregate time periods*: aggregates data based on time periods (years, months, days, hours, minutes, seconds) or in the same month of year (12 instances), day of year (365 or 366 instances), day of month (~31 instances), day of week (7 instances), hour of day (24 instances). This functionality replaces the *Aggregate widget*.
+   - *Aggregate time periods*: aggregates data based on time periods (years, months, days, hours, minutes, seconds) or in the same month of year (12 instances), week of year (52 instances), day of year (365 or 366 instances), day of month (~31 instances), day of week (7 instances), hour of day (24 instances). This functionality replaces the *Aggregate widget*.
 2. If *Apply Automatically* is ticked, changes are communicated automatically. Alternatively, click *Apply*.
 3. Variable selection:
    - Filter provides a shortcut for searching variables by (a part of) the name. Start typing the variable name to select it from the list.

--- a/doc/widgets/spiralogram.md
+++ b/doc/widgets/spiralogram.md
@@ -16,7 +16,7 @@ Spiralogram is intended for visualizing time series and for comparing attribute 
 
 ![](images/spiralogram.png)
 
-1. Units on the circumference. Options are: month of year (12 units), day of year (365 units), day of month (~30 units), day of week (Mon-Sun, 7 units), hour of day (24 units) and all the variables from the data.
+1. Units on the circumference. Options are: month of year (12 units), week of year (52 units), day of year (365 units), day of month (~30 units), day of week (Mon-Sun, 7 units), hour of day (24 units) and all the variables from the data.
 2. Unit of the vertical axis. *Hide inner labels* removes labels on the vertical axis.
 3. Color of each spiralogram section. Default is *Show instance count*. If an attribute from the data is selected, aggregation methods become available. The options are: mean value, sum, product, minimum, maximum, span, median, mode, standard deviation, variance, harmonic mean, geometric mean, non-zero count, and defined count.
 

--- a/orangecontrib/timeseries/aggregate.py
+++ b/orangecontrib/timeseries/aggregate.py
@@ -211,6 +211,8 @@ PeriodDesc("Month of year", 1, 12, "Month",
            names=calendar.month_name[1:],
            names_option="Use month names",
            value_offset=-1),
+PeriodDesc("Week of year", 2, 53, "Week",
+           value_as_period=False),
 PeriodDesc("Day of year", 2, 366, "Day",
            value_as_period=False),
 PeriodDesc("Day of month", 2, 31, "Day"),
@@ -235,6 +237,8 @@ def time_blocks(data: Timeseries,
         elif period.name == "Day of year":
             times = [d.toordinal() - date(d.year, 1, 1).toordinal() + 1
                      for d in times]
+        elif period.name == "Week of year":
+            times = [d.isocalendar()[1] for d in times]
         times = np.array(times) + period.value_offset
         if period.names and use_period_names:
             attribute = DiscreteVariable(attr_name, values=period.names)

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import reduce
+from html import escape
 from itertools import count
 from math import pi, cos, sin, atan2, degrees
 from typing import Optional, Dict, Tuple, List, Callable, Union
@@ -917,12 +918,12 @@ class OWSpiralogram(OWWidget):
             if not count:
                 continue
             if cvar:
-                tooltip = f"{cvar.name} = {cvar.repr_val(value)}<hr/>"
+                tooltip = f"{cvar.name} = {escape(cvar.repr_val(value))}<hr/>"
             else:
                 tooltip = ""
-            tooltip += f"{x_attr.name} = {x_attr.repr_val(x + lab_off)}"
+            tooltip += f"{x_attr.name} = {escape(x_attr.repr_val(x + lab_off))}"
             if r_attr:
-                tooltip += f"<br/>{r_attr.name} = {r_attr.repr_val(r)}"
+                tooltip += f"<br/>{r_attr.name} = {escape(r_attr.repr_val(r))}"
             tooltip += f"<hr/>{int(count)} instances"
 
             segment = SegmentItem.from_coordinates(

--- a/orangecontrib/timeseries/widgets/owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/owspiralogram.py
@@ -893,8 +893,11 @@ class OWSpiralogram(OWWidget):
 
         data = self.computed_data
         x_col = data.X[:, 0].astype(int)
-        if self.x_var in ("Day of year", "Day of month"):
+        if self.x_var in ("Day of year", "Day of month", "Week of year"):
+            lab_off = 1
             x_col -= 1
+        else:
+            lab_off = 0
         x_attr = data.domain[0]
         cvar = data.domain.class_var
         if self.r_var:
@@ -917,7 +920,7 @@ class OWSpiralogram(OWWidget):
                 tooltip = f"{cvar.name} = {cvar.repr_val(value)}<hr/>"
             else:
                 tooltip = ""
-            tooltip += f"{x_attr.name} = {x_attr.repr_val(x)}"
+            tooltip += f"{x_attr.name} = {x_attr.repr_val(x + lab_off)}"
             if r_attr:
                 tooltip += f"<br/>{r_attr.name} = {r_attr.repr_val(r)}"
             tooltip += f"<hr/>{int(count)} instances"

--- a/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
+++ b/orangecontrib/timeseries/widgets/tests/test_owspiralogram.py
@@ -337,7 +337,7 @@ class TestOWSpiralogram(WidgetTest):
         self.change_x(0)  # month of year
         self.assertEqual(widget.nperiods, 12)
 
-        self.change_x(3)  # day of week
+        self.change_x(4)  # day of week
         self.assertEqual(widget.nperiods, 7)
 
     def test_is_time_period(self):
@@ -442,7 +442,7 @@ class TestOWSpiralogram(WidgetTest):
              (4, 0): [7, 8],
              (5, 0): [], (6, 0): [], (7, 0): [], (8, 0): [], (9, 0): [9]})
 
-        self.change_x(3)  # day of week
+        self.change_x(4)  # day of week
         self.change_r(0)
         blocks = widget.compute_block_data()
         self.assertEqual(len(blocks.attributes[0].values), 7)


### PR DESCRIPTION
##### Issue

Implements #258.

##### Description of changes

- Add day of week to `timeseries.PeriodOptions`, which adds it to any widget that uses this list (that is, Spiralogram and Moving Transform)
- Add Day of Week into Spiralogram where it deduces the range from the name
- Fix a wrong tooltip (off by one for day of year/month and week of year)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
