### PR TITLE
Datasources - Small refactoring

### DIFF
--- a/orangecontrib/timeseries/aggregate.py
+++ b/orangecontrib/timeseries/aggregate.py
@@ -93,13 +93,13 @@ def windowed_cumprod(x, width, shift):
 
 def windowed_mode(x, width, shift):
     modes, counts = windowed_func(
-        partial(stats.mode, nan_policy='omit'),
+        # keepdims argument can be removed when we require scipy>=1.11
+        partial(stats.mode, nan_policy='omit', keepdims=False),
         x, width, shift)
-    modes = modes[:, 0]
     if np.ma.isMaskedArray(modes):
         # If counts == 0, all values were nan
         modes = modes.data
-        modes[counts[:, 0] == 0] = np.nan
+        modes[counts == 0] = np.nan
     return modes
 
 

--- a/orangecontrib/timeseries/datasources.py
+++ b/orangecontrib/timeseries/datasources.py
@@ -1,21 +1,14 @@
-from datetime import date
 import logging
-
-import pandas_datareader.data as web
-
-from pandas_datareader import data as pdr
-
-from Orange.data import Domain
-from orangecontrib.timeseries import Timeseries
+from datetime import date
 
 import yfinance as yf
+from Orange.data import Domain
+from Orange.data.pandas_compat import table_from_frame
+from pandas_datareader import data as pdr
+
+from orangecontrib.timeseries import Timeseries
 
 log = logging.getLogger(__name__)
-
-try:
-    from Orange.data.pandas_compat import table_from_frame
-except ImportError:
-    raise RuntimeError("Yahoo Finance requires Orange >= 3.9")
 
 
 def quandl_data(symbol,
@@ -55,11 +48,7 @@ def quandl_data(symbol,
     return ts
 
 
-
-def finance_data(symbol,
-                 since=None,
-                 until=None,
-                 granularity='d'):
+def finance_data(symbol, since=None, until=None):
     """Fetch Yahoo Finance data for stock or index `symbol` within the period
     after `since` and before `until` (both inclusive).
 
@@ -71,8 +60,6 @@ def finance_data(symbol,
         A start date (default: 1900-01-01).
     until: date
         An end date (default: today).
-    granularity: 'd' or 'w' or 'm' or 'v'
-        What data to get: daily, weekly, monthly, or dividends.
 
     Returns
     -------
@@ -91,9 +78,7 @@ def finance_data(symbol,
     # Make Adjusted Close a class variable
     attrs = [var.name for var in data.domain.attributes]
     attrs.remove('Adj Close')
-    data = Timeseries.from_table(Domain(attrs, [data.domain['Adj Close']],
-                                        None, source=data.domain),
-                                 data)
+    data = data.transform(Domain(attrs, [data.domain['Adj Close']], source=data.domain))
 
     data.name = symbol
     data.time_variable = data.domain['Date']

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
             'pandas',  # statsmodels requires this but doesn't have it in dependencies?
             'pandas_datareader',
             'numpy',
-            'scipy>=0.17',
+            'scipy>=1.9.2',
             'more-itertools',
             # required to get current timezone
             # adding it does not hurt, Pandas have it as a dependency

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     # orange3 requires the following
     oldest: orange-widget-base==4.18.0
     oldest: orange-canvas-core==0.1.27
+    oldest: scipy==1.9.2
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- While considering #257, I found that the code can be refactored.
- Aggregation tests are failing since Scipy changed the behaviour of stats functions.

##### Description of changes
- Refactoring the code of the Datasources module.
- Fix weighted_mode function: Before stats.mode had `keepdims=True` like behaviour by default, which changed in 1.11. Since it is `False,` now the result is a one-dimensional vector, so I removed the part of the code that extracts the first column. I also limited the version of Scipy to >=1.9 since it is the first version offering the `keepdims` parameter.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
