### PR TITLE
[FIX] Temporarily skip installing yfinace and pandas_datareader for MacOS

### DIFF
--- a/orangecontrib/timeseries/tests/test_lxml.py
+++ b/orangecontrib/timeseries/tests/test_lxml.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+
+class TestReintroduceYahoo(unittest.TestCase):
+    def test_time_bomb(self):
+        """
+        When this test start to fail, check if there are already ARM wheels for
+        LXML library for Python 3.9 and 3.10. If they exist revert commit that part
+        of it is also this test.
+        """
+        self.assertLess(datetime.now(), datetime(2024, 1, 1), "Happy new year")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -66,14 +66,14 @@ if __name__ == '__main__':
             'statsmodels>=0.13.0',
             'python-dateutil',
             'pandas',  # statsmodels requires this but doesn't have it in dependencies?
-            'pandas_datareader',
+            'pandas_datareader; sys_platform!="darwin"',
             'numpy',
             'scipy>=1.9.2',
             'more-itertools',
             # required to get current timezone
             # adding it does not hurt, Pandas have it as a dependency
             'python-dateutil',
-            'yfinance',
+            'yfinance; sys_platform!="darwin"',
             'pyqtgraph>=0.13.1',
         ],
         extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     oldest: orange-widget-base==4.18.0
     oldest: orange-canvas-core==0.1.27
     oldest: scipy==1.9.2
+    oldest: pandas==1.4.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes (partially) #261 

##### Description of changes
Until LXML provides wheels for ARM MacOS, I will skip the installation of yfince and pandas_datareader. Both of them require lxml. It will affect the Yahoo widget, which will not be shown on MacOS. It is just a temporary solution and hopefully can be reverted soon. I am helping lxml to provide the missing wheels.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
