### PR TITLE
[DOC] Rename As Timeseries to Form Timeseries

### DIFF
--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -10,7 +10,7 @@
     "keywords": []
    },
    {
-    "text": "As Timeseries",
+    "text": "Form Timeseries",
     "doc": "widgets/as_timeseries.md",
     "icon": "../orangecontrib/timeseries/widgets/icons/TableToTimeseries.svg",
     "background": "#33aaff",

--- a/doc/widgets/as_timeseries.md
+++ b/doc/widgets/as_timeseries.md
@@ -1,5 +1,5 @@
-As Timeseries
-=============
+Form Timeseries
+===============
 
 Reinterpret a **Table** object as a Timeseries object.
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Hopefully, fixes #254. Even after `make html` the widget did not appear. However, the generated index was ok and was able to search it.

##### Description of changes
Rename widget.json to appropriate widget name. Fix widget title for Form Timeseries docs.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
